### PR TITLE
deps update

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "webda.io",
   "private": true,
   "devDependencies": {
-    "@commitlint/config-conventional": "^15.0.0",
+    "@commitlint/config-conventional": "^16.2.1",
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
     "@types/json-schema": "^7.0.8",
     "@types/mocha": "^9.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,7 @@
     "cookie": "^0.4.1",
     "dateformat": "^5.0.3",
     "deepmerge-ts": "^4.0.3",
-    "email-templates": "^8.0.7",
+    "email-templates": "^9.0.0",
     "fs-finder": "^1.8.1",
     "glob": "^7.1.7",
     "global": "^4.4.0",

--- a/packages/profiler-aws-xray/package.json
+++ b/packages/profiler-aws-xray/package.json
@@ -53,7 +53,6 @@
     "@testdeck/mocha": "^0.2.0",
     "@types/node": "14.0.0",
     "@webda/shell": "^1.6.0-beta.3",
-    "aws-sdk-mock": "=5.4.0",
     "sinon": "^12.0.1"
   }
 }

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -56,7 +56,7 @@
     "semver": "^7.3.5",
     "semver-intersect": "^1.4.0",
     "socket.io": "^4.1.3",
-    "ts-json-schema-generator": "~0.98.1-next.1",
+    "ts-json-schema-generator": "~1.0.0",
     "typescript": "~4.6.3",
     "unzipper": "^0.10.11",
     "yaml": "^1.10.2",


### PR DESCRIPTION
- chore(deps-dev): bump @commitlint/config-conventional
- ci: remove aws-sdk-mock library
- chore(deps): bump ts-json-schema-generator from 0.98.1-next.4 to 1.0.0
- chore(deps): bump email-templates from 8.1.0 to 9.0.0

## Changes

*please link the issues here*

Changes proposed in this pull request
