### PR TITLE
feat: operations exporter

### DIFF
--- a/docs/pages/Concepts/AsyncActions.md
+++ b/docs/pages/Concepts/AsyncActions.md
@@ -15,6 +15,8 @@ Currently to use Cron with something else than an AsyncOperationAction, you need
 
 ## Architecture
 
+Flow with a Queue 
+
 ```mermaid
 sequenceDiagram
 	participant Q as Queue
@@ -28,7 +30,7 @@ sequenceDiagram
     Q->>Ar: Retrieve Queue item
 	activate Ar
 	Ar->>S: Move action to 'STARTING' status
-	Ar->>O: Run action
+	Ar->>R: Run action
 	R->>J: Launch Job
 	R->>Ar: Return Runner Job Info
 	Ar->>S: Save Runner Job Info
@@ -41,6 +43,50 @@ sequenceDiagram
 	end
 ```
 
+Flow with local run and http hook status
+
+```mermaid
+sequenceDiagram
+    participant S as Store
+    participant Ar as AsyncActionService Worker
+	participant R as Runner
+	participant J as Job
+    Ar->>S: Create new action in 'QUEUED' status
+	activate Ar
+	Ar->>S: Move action to 'STARTING' status
+	Ar->>R: Run action
+	R->>J: Launch Job
+	R->>Ar: Return Runner Job Info
+	Ar->>S: Save Runner Job Info
+	deactivate Ar
+	loop status report
+		J->>Ar: Use hook /async/status to report
+		activate Aa
+		Ar->>S: Update status from report
+		deactivate Aa
+	end
+```
+
+Flow with local run with WebdaAction only
+
+```mermaid
+sequenceDiagram
+    participant S as Store
+    participant Ar as AsyncActionService Worker
+	participant R as Runner
+	participant J as Job
+    Ar->>S: Create new action in 'QUEUED' status
+	activate Ar
+	Ar->>S: Move action to 'STARTING' status
+	Ar->>R: Run action
+	R->>J: Launch Job
+	R->>Ar: Return Runner Job Info
+	Ar->>S: Save Runner Job Info
+	deactivate Ar
+	loop status report
+		J->>S: Update status direclty in Store
+	end
+```
 ## Runner
 
 The runner is the service responsible to launch the action effectively.

--- a/packages/async/src/models.ts
+++ b/packages/async/src/models.ts
@@ -1,4 +1,5 @@
-import { CoreModel } from "@webda/core";
+import { CoreModel, OperationContext } from "@webda/core";
+import { WorkerLogLevel } from "@webda/workout";
 
 /**
  * Represent an item for processing queue
@@ -36,6 +37,15 @@ export default class AsyncAction extends CoreModel {
     this.type = this.constructor.name;
   }
 
+  /**
+   * By default AsyncAction are not considered internal
+   *
+   * Internal: That execute a method or operation of Webda application framework
+   * @returns
+   */
+  isInternal(): boolean {
+    return false;
+  }
   /**
    * Action uuid
    */
@@ -103,17 +113,47 @@ export default class AsyncAction extends CoreModel {
 
 /**
  * Define a Webda Async Action
+ *
+ * @WebdaModel
  */
-export class AsyncOperationAction extends AsyncAction {
+export class AsyncWebdaAction extends AsyncAction {
+  public logLevel: WorkerLogLevel = "INFO";
   /**
    *
    * @param serviceName service to call
    * @param method method to call
    * @param arguments to call with the method
    */
-  constructor(public serviceName?: string, public method?: string, args?: any[]) {
+  constructor(public serviceName?: string, public method?: string, ...args: any[]) {
     super();
     this.arguments = args;
+  }
+
+  /**
+   * Execute a serviceName.method(...args) so this is internal
+   * @returns
+   */
+  isInternal() {
+    return true;
+  }
+}
+
+/**
+ * Operation called asynchronously
+ *
+ * @WebdaModel
+ */
+export class AsyncOperationAction extends AsyncAction {
+  constructor(public operationId: string, public context: OperationContext, public logLevel: WorkerLogLevel = "INFO") {
+    super();
+  }
+
+  /**
+   * Execute a webda.callOperation(context ,id) so this is internal
+   * @returns
+   */
+  isInternal() {
+    return true;
   }
 }
 

--- a/packages/async/src/services/servicerunner.spec.ts
+++ b/packages/async/src/services/servicerunner.spec.ts
@@ -1,8 +1,8 @@
 import { suite, test } from "@testdeck/mocha";
-import { Store } from "@webda/core";
+import { Operation, OperationContext, Store } from "@webda/core";
 import { WebdaTest } from "@webda/core/lib/test";
 import assert from "assert";
-import models, { AsyncAction, AsyncOperationAction } from "../models";
+import models, { AsyncAction, AsyncOperationAction, AsyncWebdaAction } from "../models";
 import { Runner } from "./runner";
 import ServiceRunner from "./servicerunner";
 
@@ -17,17 +17,23 @@ class FakeRunner extends Runner {
       throw new Error("Error");
     }
   }
+
+  @Operation()
+  operation(ctx) {
+    this.log("INFO", "Logging test");
+  }
 }
 
 @suite
 class ServiceRunnerTest extends WebdaTest {
   @test
-  async cov() {
+  async operationAction() {
     this.registerService(new FakeRunner(this.webda, "calledRunner"));
+    this.webda.initStatics();
     let runner = new ServiceRunner(this.webda, "runner", { actions: ["plop"] });
-    const action = new AsyncOperationAction();
-    action.serviceName = "calledRunner";
-    action.method = "test";
+    console.log(this.webda.listOperations());
+    const ctx = new OperationContext(this.webda);
+    const action = new AsyncOperationAction("calledRunner.testOp", ctx);
     await this.getService<Store<AsyncAction>>("AsyncJobs").save(action);
     await runner.launchAction(action, {
       JOB_HOOK: "",
@@ -35,21 +41,43 @@ class ServiceRunnerTest extends WebdaTest {
       JOB_ORCHESTRATOR: "test",
       JOB_SECRET_KEY: ""
     });
-    const action2 = new AsyncOperationAction();
+  }
+
+  @test
+  async cov() {
+    this.registerService(new FakeRunner(this.webda, "calledRunner"));
+    let runner = new ServiceRunner(this.webda, "runner", { actions: ["plop"] });
+    const action = new AsyncWebdaAction();
+    action.serviceName = "calledRunner";
+    action.method = "test";
+    await this.getService<Store<AsyncAction>>("AsyncJobs").save(action);
+    let serviceAction = await runner.launchAction(action, {
+      JOB_HOOK: "",
+      JOB_ID: action.getUuid(),
+      JOB_ORCHESTRATOR: "test",
+      JOB_SECRET_KEY: ""
+    });
+    await serviceAction.promise;
+    await action.refresh();
+    assert.strictEqual(action.logs?.length, 1);
+    assert.ok(action.logs[0].endsWith(" [ INFO] [calledRunner] FakeRunner test undefined"));
+    const action2 = new AsyncWebdaAction();
     action2.serviceName = "calledRunner";
     action2.method = "test";
     action2.arguments = [666];
     await this.getService<Store<AsyncAction>>("AsyncJobs").save(action2);
-    await runner.launchAction(action2, {
+    serviceAction = await runner.launchAction(action2, {
       JOB_HOOK: "",
       JOB_ID: action2.getUuid(),
       JOB_ORCHESTRATOR: "test",
       JOB_SECRET_KEY: ""
     });
-    await this.sleep(200);
+    await serviceAction.promise;
     await action2.refresh();
     assert.strictEqual(action2.status, "ERROR");
-
+    console.log(action2);
+    assert.strictEqual(action2.logs?.length, 1);
+    assert.ok(action2.logs[0].endsWith(" [ INFO] [calledRunner] FakeRunner test 666"));
     action.type = "plop";
     await assert.rejects(
       () =>
@@ -59,7 +87,23 @@ class ServiceRunnerTest extends WebdaTest {
           JOB_ORCHESTRATOR: "test",
           JOB_SECRET_KEY: ""
         }),
-      /Can only handle AsyncOperationAction got plop/
+      /Can only handle AsyncWebdaAction or AsyncOperationAction got plop/
     );
+
+    const opAction = new AsyncOperationAction("calledRunner.operation", new OperationContext(this.webda));
+    this.webda.initStatics();
+    await this.getService<Store<AsyncAction>>("AsyncJobs").save(opAction);
+    serviceAction = await runner.launchAction(opAction, {
+      JOB_HOOK: "",
+      JOB_ID: opAction.getUuid(),
+      JOB_ORCHESTRATOR: "test",
+      JOB_SECRET_KEY: ""
+    });
+    await serviceAction.promise;
+    await opAction.refresh();
+    console.log(opAction);
+    assert.strictEqual(opAction.status, "ERROR");
+    assert.strictEqual(opAction.logs?.length, 1);
+    assert.ok(action2.logs[0].endsWith(" [ INFO] [calledRunner] Logging test"));
   }
 }

--- a/packages/async/src/services/servicerunner.ts
+++ b/packages/async/src/services/servicerunner.ts
@@ -45,15 +45,7 @@ export class ActionMemoryLogger extends MemoryLogger {
 
   save(): Promise<void> {
     this.timeout = undefined;
-    return (
-      this.action
-        // @ts-ignore
-        .patch({ logs: this.getLogs().map(msg => ConsoleLogger.format(msg, this.format)) }, null)
-        .then(async () => {
-          console.log("ACTION", this.action);
-          console.log("OK SAVE DONE", await this.action.getStore().get(this.action.getUuid()));
-        })
-    );
+    return this.action.patch({ logs: this.getLogs().map(msg => ConsoleLogger.format(msg, this.format)) }, null);
   }
 
   async saveAndClose() {

--- a/packages/async/src/services/servicerunner.ts
+++ b/packages/async/src/services/servicerunner.ts
@@ -1,12 +1,88 @@
-import { AsyncAction, AsyncOperationAction } from "../models";
-import { JobInfo } from "./asyncjobservice";
+import { ConsoleLogger, MemoryLogger, WorkerLogLevel, WorkerMessage, WorkerOutput } from "@webda/workout";
+import { AsyncAction, AsyncOperationAction, AsyncWebdaAction } from "../models";
+import AsyncJobService, { JobInfo } from "./asyncjobservice";
 import { AgentInfo, Runner, RunnerParameters } from "./runner";
 
 /**
  * Type of action returned by LocalRunner
  */
 export interface ServiceAction {
+  /**
+   * Info on the server running it
+   */
   agent: AgentInfo;
+  /**
+   * Promise of the implementation
+   *
+   * Useful for unit test
+   */
+  promise: Promise<void>;
+}
+
+/**
+ * Keep log in memory and save it to the action object every 5s
+ */
+export class ActionMemoryLogger extends MemoryLogger {
+  protected timeout: NodeJS.Timeout;
+
+  constructor(
+    output: WorkerOutput,
+    level: WorkerLogLevel,
+    limit: number,
+    protected action: AsyncAction,
+    public logSaveDelay: number,
+    public format?: string
+  ) {
+    super(output, level, limit);
+  }
+
+  onMessage(msg: WorkerMessage) {
+    super.onMessage(msg);
+    if (!this.timeout) {
+      setTimeout(() => this.save(), this.logSaveDelay);
+    }
+  }
+
+  save(): Promise<void> {
+    this.timeout = undefined;
+    return (
+      this.action
+        // @ts-ignore
+        .patch({ logs: this.getLogs().map(msg => ConsoleLogger.format(msg, this.format)) }, null)
+        .then(async () => {
+          console.log("ACTION", this.action);
+          console.log("OK SAVE DONE", await this.action.getStore().get(this.action.getUuid()));
+        })
+    );
+  }
+
+  async saveAndClose() {
+    this.close();
+    return this.save();
+  }
+}
+
+/**
+ * Add the log format to capture
+ */
+export class ServiceRunnerParameters extends RunnerParameters {
+  /**
+   * Define the log format
+   *
+   * @default ConsoleLoggerDefaultFormat
+   */
+  logFormat?: string;
+  /**
+   * How long before saving logs (in ms)
+   *
+   * @default 5000
+   */
+  logSaveDelay?: number;
+
+  constructor(params: any) {
+    super(params);
+    this.logSaveDelay ??= 5000;
+  }
 }
 
 /**
@@ -14,36 +90,63 @@ export interface ServiceAction {
  *
  * @WebdaModda
  */
-export default class ServiceRunner<T extends RunnerParameters = RunnerParameters> extends Runner<T> {
+export default class ServiceRunner<T extends ServiceRunnerParameters = ServiceRunnerParameters> extends Runner<T> {
+  /**
+   * Load parameters
+   * @param params
+   * @returns
+   */
+  loadParameters(params: any) {
+    return new ServiceRunnerParameters(params);
+  }
   /**
    * @inheritdoc
    */
   async launchAction(action: AsyncAction, info: JobInfo): Promise<ServiceAction> {
-    if (action.type !== "AsyncOperationAction") {
-      this.log("ERROR", "Can only handle AsyncOperationAction got", action.type);
-      throw new Error("Can only handle AsyncOperationAction got " + action.type);
+    if (action.type !== "AsyncWebdaAction" && action.type !== "AsyncOperationAction") {
+      this.log("ERROR", "Can only handle AsyncWebdaAction or AsyncOperationAction got", action.type);
+      throw new Error("Can only handle AsyncWebdaAction or AsyncOperationAction got " + action.type);
     }
-    const webdaAction = <AsyncOperationAction>action;
 
     // Launch within current process
-    (async () => {
+    let promise = (async (action: AsyncWebdaAction | AsyncOperationAction) => {
+      let logger;
       try {
         await action.patch({ status: "RUNNING" });
         this.log("INFO", "Job", action.getUuid(), "started");
-        await this.getService(webdaAction.serviceName)[webdaAction.method](...(webdaAction.arguments || []));
+        // Inject a MemoryLogger to capture and report any logs
+        logger = new ActionMemoryLogger(
+          this.getWebda().getWorkerOutput(),
+          action.logLevel,
+          this.getService<AsyncJobService>(info.JOB_ORCHESTRATOR)?.getParameters().logsLimit || 5000,
+          action,
+          this.parameters.logSaveDelay,
+          this.parameters.logFormat
+        );
+        if (action.type === "AsyncWebdaAction") {
+          const webdaAction = <AsyncWebdaAction>action;
+          await this.getService(webdaAction.serviceName)[webdaAction.method](...(webdaAction.arguments || []));
+        } else {
+          const operationAction = <AsyncOperationAction>action;
+          await this.getWebda().callOperation(operationAction.context, operationAction.operationId);
+        }
+        await logger.saveAndClose();
+
         await action.patch({ status: "SUCCESS" });
         this.log("INFO", "Job", action.getUuid(), "finished");
       } catch (err) {
+        await logger?.saveAndClose();
         await action.patch({
           status: "ERROR",
           errorMessage: JSON.stringify(err, Object.getOwnPropertyNames(err))
         });
         this.log("INFO", "Job", action.getUuid(), "errored", err);
       }
-    })();
+    })(<AsyncOperationAction | AsyncWebdaAction>action);
 
     return {
-      agent: Runner.getAgentInfo()
+      agent: Runner.getAgentInfo(),
+      promise
     };
   }
 }

--- a/packages/core/src/application.spec.ts
+++ b/packages/core/src/application.spec.ts
@@ -2,6 +2,8 @@ import { suite, test } from "@testdeck/mocha";
 import * as assert from "assert";
 import * as path from "path";
 import { Application, UnpackedApplication } from "./index";
+import { CoreModel } from "./models/coremodel";
+import { User } from "./models/user";
 import { TestApplication, WebdaTest } from "./test";
 import { getCommonJS } from "./utils/esm";
 const { __dirname } = getCommonJS(import.meta.url);
@@ -154,6 +156,8 @@ class ApplicationTest extends WebdaTest {
     // @ts-ignore
     unpackedApp.baseConfiguration.cachedModules.project.webda = undefined;
     assert.deepStrictEqual(unpackedApp.getPackageWebda(), { namespace: "Webda" });
+    assert.strictEqual(app.getModelFromInstance(new CoreModel()), "webda/coremodel");
+    assert.strictEqual(app.getModelFromInstance(new User()), "webda/user");
   }
 
   @test

--- a/packages/core/src/application.ts
+++ b/packages/core/src/application.ts
@@ -631,6 +631,16 @@ export class Application {
   }
 
   /**
+   * Return the model name for a object
+   * @param object
+   */
+  getModelFromInstance(object): string | undefined {
+    return Object.keys(this.models)
+      .filter(k => this.models[k] === object.constructor)
+      .pop();
+  }
+
+  /**
    * Return all deployers
    */
   getDeployers(): { [key: string]: Modda } {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -537,7 +537,11 @@ export class Core<E extends CoreEvents = CoreEvents> extends events.EventEmitter
       throw new Error(`Unknown Operation Id: ${operationId}`);
     }
     let input = await context.getInput();
-    if (input === undefined || this.validateSchema(this.operations[operationId].input, input) !== true) {
+    this.log("TRACE", `Operation ${operationId} input is '${JSONUtils.safeStringify(input, undefined, 2)}'`);
+    if (
+      this.operations[operationId].input &&
+      (input === undefined || this.validateSchema(this.operations[operationId].input, input) !== true)
+    ) {
       throw new Error("Input does not fit the operation input");
     }
     return this.getService(this.operations[operationId].service)[this.operations[operationId].method](context);

--- a/packages/core/src/models/coremodel.ts
+++ b/packages/core/src/models/coremodel.ts
@@ -380,7 +380,6 @@ class CoreModel {
     if (this._lastUpdate) {
       this._lastUpdate = new Date(this._lastUpdate);
     }
-    this.__type = this.__class.name;
 
     if (!this.getUuid()) {
       this.setUuid(this.generateUid(raw));
@@ -539,7 +538,6 @@ class CoreModel {
    */
   toStoredJSON(stringify = false): any | string {
     let obj = this._toJSON(true);
-    obj.__type = this.__class.name;
     if (stringify) {
       return JSON.stringify(obj);
     }

--- a/packages/core/src/services/service.spec.ts
+++ b/packages/core/src/services/service.spec.ts
@@ -20,12 +20,13 @@ class FakeService<T extends FakeServiceParameters = FakeServiceParameters> exten
   @Inject("params:bean", undefined, false)
   serv4: Service;
 
-  @Operation("myOperation", "test", "plop", "/operation/plop")
+  // Set to undefined to ensure fallback on method name
+  @Operation({ input: "test", output: "plop" }, { url: "/operation/plop" })
   async myOperation(ctx: OperationContext<{ output: string }>) {
     ctx.write((await ctx.getInput()).output);
   }
 
-  @Operation("myOperation")
+  @Operation({ id: "myOperation" })
   myOperation2(ctx: OperationContext) {
     ctx.write("plop2");
   }
@@ -113,6 +114,7 @@ class ServiceTest extends WebdaTest {
     // Check the list
     assert.deepStrictEqual(this.webda.listOperations(), {
       "plop.myOperation": {
+        id: "plop.myOperation",
         input: "webda/test",
         output: "webda/plop"
       }

--- a/packages/core/src/stores/file.spec.ts
+++ b/packages/core/src/stores/file.spec.ts
@@ -61,6 +61,7 @@ class FileStoreTest extends StoreTest {
     let ident = await identStore.save({
       _user: user.getUuid()
     });
+    identStore.getParameters().strict = true;
     let res = await identStore.get(user.getUuid());
     assert.strictEqual(res, undefined);
     const stub = sinon.stub(identStore, "_get").callsFake(async () => user);

--- a/packages/core/src/stores/file.ts
+++ b/packages/core/src/stores/file.ts
@@ -219,7 +219,7 @@ class FileStore<T extends CoreModel, K extends FileStoreParameters = FileStorePa
     let res = await this.exists(uid);
     if (res) {
       let data = JSON.parse(fs.readFileSync(this.file(uid)).toString());
-      if (data.__type !== this._model.name && this.parameters.strict) {
+      if (data.__type !== this._modelType && this.parameters.strict) {
         return undefined;
       }
       return this.initModel(data);

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -139,6 +139,10 @@ abstract class StoreTest extends WebdaTest {
 
     // Verify permission issue and half pagination
     userStore.setModel(PermissionModel);
+    userStore.getParameters().forceModel = true;
+    if (userStore._cacheStore) {
+      userStore._cacheStore.getParameters().forceModel = true;
+    }
     let context = await this.newContext();
     // Verify pagination system
     i = 0;

--- a/packages/core/src/utils/context.ts
+++ b/packages/core/src/utils/context.ts
@@ -178,17 +178,17 @@ export class OperationContext<T = any, U = any> extends EventEmitter {
    * @returns
    */
   async getRawInputAsString(
-    _limit: number = 1024 * 1024 * 10,
-    _timeout: number = 60000,
-    _encoding?: string
+    limit: number = 1024 * 1024 * 10,
+    timeout: number = 60000,
+    encoding?: BufferEncoding
   ): Promise<string> {
-    return "";
+    return (await this.getRawInput(limit, timeout)).toString(encoding);
   }
 
   /**
    * @override
    */
-  async getRawInput(limit: number = 1024 * 1024 * 10, timeout: number = 60000): Promise<Buffer> {
+  async getRawInput(_limit: number = 1024 * 1024 * 10, _timeout: number = 60000): Promise<Buffer> {
     return Buffer.from("");
   }
 
@@ -336,6 +336,24 @@ export class OperationContext<T = any, U = any> extends EventEmitter {
   }
 }
 
+/**
+ * Simple Operation Context with custom input
+ */
+export class SimpleOperationContext extends OperationContext {
+  input: Buffer;
+
+  setInput(input: Buffer): this {
+    this.input = input;
+    return this;
+  }
+
+  /**
+   * @override
+   */
+  async getRawInput(limit: number = 1024 * 1024 * 10, _timeout: number = 60000): Promise<Buffer> {
+    return this.input.slice(0, limit);
+  }
+}
 /**
  * This represent in fact a WebContext
  * In 3.0 an abstract version of Context will replace this (closer to OperationContext)

--- a/packages/core/src/utils/cookie.spec.ts
+++ b/packages/core/src/utils/cookie.spec.ts
@@ -3,6 +3,7 @@ import * as assert from "assert";
 import { serialize as cookieSerialize } from "cookie";
 import { Context, SecureCookie } from "../index";
 import { WebdaTest } from "../test";
+import { SimpleOperationContext } from "./context";
 import { HttpContext } from "./httpcontext";
 import { Session } from "./session";
 
@@ -217,6 +218,10 @@ class CookieTest extends WebdaTest {
   async cov() {
     let session = await SecureCookie.load("test", new Context(this.webda, undefined, undefined), undefined);
     assert.strictEqual(Object.keys(session).length, 0);
+    assert.strictEqual(
+      await new SimpleOperationContext(this.webda).setInput(Buffer.from("plop")).getRawInputAsString(),
+      "plop"
+    );
   }
 
   @test("Oversize cookie") async testOversize() {

--- a/packages/shell/src/console/webda.ts
+++ b/packages/shell/src/console/webda.ts
@@ -34,7 +34,7 @@ export interface OperationsExportFormat {
     version: string;
     author?: PackageDescriptorAuthor;
   };
-  operations: { [key: string]: { input: string; output?: string } };
+  operations: { [key: string]: { input?: string; output?: string; permission?: string; id: string } };
   schemas: { [key: string]: JSONSchema7 };
 }
 
@@ -157,7 +157,9 @@ export default class WebdaConsole {
     };
     // Copy all schemas
     Object.values(operations).forEach(ope => {
-      operationsExport.schemas[ope.input] ??= this.app.getSchema(ope.input);
+      if (ope.input) {
+        operationsExport.schemas[ope.input] ??= this.app.getSchema(ope.input);
+      }
       if (ope.output) {
         operationsExport.schemas[ope.output] ??= this.app.getSchema(ope.output);
       }

--- a/sample-app/src/services/custom.ts
+++ b/sample-app/src/services/custom.ts
@@ -63,11 +63,11 @@ class CustomService<T extends CustomParameters = CustomParameters> extends Servi
     ctx.write("Tested");
   }
 
-  @Operation("testOperation", "testInput")
+  @Operation({ input: "testInput" })
   testOperation(ctx: OperationContext) {}
 
-  @Operation("testOperationWithOutput", "testInput", "testOutput")
-  testOperation2(ctx: OperationContext) {}
+  @Operation({ input: "testInput", output: "testOutput" })
+  testOperationWithOutput(ctx: OperationContext) {}
   /**
    * @MMD {seq:MyGraph} My step 1
    */


### PR DESCRIPTION
## Changes

### Store multi model

You can now store several model within the same Store, very useful for registry type of Store.

A default model is still existing, for things created through POST api, the `factory` concept in that case allows you to create different type of Model based on the content of the POST

New store parameters have been added:
`defaultModel`: if the stored object relate to a model that does not exist in the app, it will use the default store model
`forceModel`: make the store ignore completely the stored \_\_type to always use its default model defined in the parameter `model`

This update is not a BREAKING CHANGE, because the Store parameters default paremeters are now:

```
 defaultModel: true,
 forceModel: false,
 strict: false
```