### PR TITLE
Update package.json

### DIFF
--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -38,6 +38,7 @@
     "@webda/tsc-esm": "^1.0.2",
     "@webda/workout": "^2.3.0",
     "archiver": "^5.3.0",
+    "chalk": "^5.0.1",
     "cli-progress": "^3.9.0",
     "colors": "=1.4.0",
     "dateformat": "^5.0.3",


### PR DESCRIPTION
add missing dependency of chalk in shell
chalk is used in console/webda.ts however this dependency is not declared
