### PR TITLE
next

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "merge-stream": "^2.0.0",
     "mocha": ">=9.0.2",
     "nyc": "^15.0.1",
-    "prettier": "^2.3.2",
+    "prettier": "^3.0.0",
     "prettier-plugin-organize-imports": "^3.0.0",
     "sinon": "^15.0.0",
     "ts-node": "^10.1.0",

--- a/packages/aws/package.json
+++ b/packages/aws/package.json
@@ -79,7 +79,7 @@
     "@webda/async": "^3.0.5",
     "@webda/shell": "^3.1.2",
     "aws-lambda": "^1.0.7",
-    "aws-sdk-client-mock": "^2.0.1",
+    "aws-sdk-client-mock": "^3.0.0",
     "node-fetch": "^3.3.1",
     "sinon": "^15.0.0"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
     "c8": "^8.0.0",
     "fs-extra": "^11.0.0",
     "mocha": "^10.0.0",
-    "prettier": "^2.3.2",
+    "prettier": "^3.0.0",
     "sinon": "^15.0.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.1.0",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -37,7 +37,7 @@
     "glob": "^10.0.0",
     "js-beautify": "^1.14.7",
     "mocha": "^10.2.0",
-    "prettier": "^2.8.4",
+    "prettier": "^3.0.0",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.2"

--- a/packages/workout/package.json
+++ b/packages/workout/package.json
@@ -32,7 +32,7 @@
     "c8": "^8.0.0",
     "mocha": "^10.0.0",
     "mock-stdin": "^1.0.0",
-    "prettier": "^2.3.2",
+    "prettier": "^3.0.0",
     "sinon": "^15.0.0",
     "source-map-support": "^0.5.19",
     "ts-node": "^10.1.0",


### PR DESCRIPTION
- chore(deps-dev): bump aws-sdk-client-mock from 2.2.0 to 3.0.0
- chore(deps-dev): bump prettier from 2.8.8 to 3.0.0

## Changes

*please link the issues here*

Changes proposed in this pull request
