### PR TITLE
chore(gcp): improve permission error tracability

### DIFF
--- a/packages/gcp/src/services/storage.ts
+++ b/packages/gcp/src/services/storage.ts
@@ -107,6 +107,7 @@ export default class Storage<T extends StorageParameters = StorageParameters> ex
    * @param {StorageObject} params
    */
   async getContent({ bucket, key }: StorageObject): Promise<Readable> {
+    this._webda.log("TRACE", `webda::gcp::storage::getContent(gs://${bucket}/${key}) starting...`);
     return this.getStorageBucket(bucket).file(key).createReadStream();
   }
 


### PR DESCRIPTION
needed THIS to be able to easily dig (saves time) of the failure in the canonical log :

```
024-08-06T23:42:30.638Z [ERROR] Init service AutomationService failed: Anonymous caller does not have storage.objects.get access to the Google Cloud Storage object. Permission &#39;storage.objects.get&#39; denied on resource (or it may not exist).
```