### PR TITLE
async fix2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pnpm-lock.yaml
 .nx
 .webda
 coverage
+docs/build

--- a/localtest.sh
+++ b/localtest.sh
@@ -10,7 +10,7 @@ echo "Launching MongoDB"
 docker run --name webda-mongo -e MONGO_INITDB_ROOT_USERNAME=root -e MONGO_INITDB_ROOT_PASSWORD=webda.io --name webda-mongo -p 37017:27017 -d mongo
 
 echo "Launching Postgres"
-docker run -d --name webda-postgres -v `pwd`/packages/postgres/test/sql:/docker-entrypoint-initdb.d -it -e POSTGRES_PASSWORD=webda.io -e POSTGRES_DB=webda.io -e POSTGRES_USER=webda.io -p 5432:5432 docker.io/library/postgres:13
+docker run -d --name webda-postgres -v `pwd`/packages/postgres/test/sql:/docker-entrypoint-initdb.d -it -e POSTGRES_PASSWORD=webda.io -e POSTGRES_DB=webda.io -e POSTGRES_USER=webda.io -p 5432:5432 docker.io/library/postgres:17
 
 echo "Launching GCP emulators"
 gcloud beta emulators firestore start --host-port=localhost:19090

--- a/packages/core/src/stores/webdaql/query.spec.ts
+++ b/packages/core/src/stores/webdaql/query.spec.ts
@@ -155,6 +155,30 @@ class QueryTest {
   }
 
   @test
+  escape() {
+    const test = {
+      attr1: "pl'op",
+      attr2: 'pl"op'
+    };
+    assert.strictEqual(new WebdaQL.QueryValidator("attr1 = 'pl\\'op'").eval(test), true, "Escape single quote");
+    assert.strictEqual(new WebdaQL.QueryValidator("attr2 = 'pl\"op'").eval(test), true, "Double quote in simple quote");
+    assert.strictEqual(
+      new WebdaQL.QueryValidator('attr2 = "pl\\"op"').eval(test),
+      true,
+      "Double quote in double quote"
+    );
+    assert.throws(() => new WebdaQL.QueryValidator("attr1 = 'pl\\\\'op'").eval({ attr1: "pl'op" }), SyntaxError);
+    assert.strictEqual(
+      new WebdaQL.QueryValidator("attr1 = 'pl\\\\\\'op'").eval(test),
+      false,
+      "Escape double backslash"
+    );
+
+    assert.throws(() => new WebdaQL.QueryValidator("na'me = 'test'"), /SyntaxError/);
+    assert.throws(() => new WebdaQL.QueryValidator("na\"me = 'test'"), /SyntaxError/);
+  }
+
+  @test
   contains() {
     assert.strictEqual(new WebdaQL.QueryValidator("test.attr1 CONTAINS 'plop2'").eval(targets[0]), false);
   }

--- a/packages/core/src/stores/webdaql/query.ts
+++ b/packages/core/src/stores/webdaql/query.ts
@@ -247,7 +247,13 @@ export namespace WebdaQL {
      * Read the string literal (removing the simple or double bracket)
      */
     visitStringLiteral(ctx: StringLiteralContext): string {
-      return ctx.text.substring(1, ctx.text.length - 1);
+      let text = ctx.text.substring(1, ctx.text.length - 1);
+      if (ctx.text[0] === '"') {
+        text = text.replace(/\\"/g, '"');
+      } else {
+        text = text.replace(/\\'/g, "'");
+      }
+      return text;
     }
 
     /**

--- a/packages/hawk/README.md
+++ b/packages/hawk/README.md
@@ -1,0 +1,33 @@
+# @webda/hawk module
+
+This module is part of Webda Application Framework that allows you to quickly develop applications with all modern prerequisites: Security, Extensibility, GraphQL, REST, CloudNative [https://webda.io](https://webda.io)
+
+<img src="https://webda.io/images/webda.svg" width="128" />
+
+![CI](https://github.com/loopingz/webda.io/workflows/CI/badge.svg)
+
+[![Join the chat at https://gitter.im/loopingz/webda](https://badges.gitter.im/loopingz/webda.svg)](https://gitter.im/loopingz/webda?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov](https://codecov.io/gh/loopingz/webda.io/branch/main/graph/badge.svg?token=8N9DNM3K3O)](https://codecov.io/gh/loopingz/webda.io)
+[![SonarCloud.io](https://sonarcloud.io/api/project_badges/measure?project=loopingz_webda.io&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=loopingz_webda.io)
+![CodeQL](https://github.com/loopingz/webda.io/workflows/CodeQL/badge.svg)
+
+<!-- README_HEADER -->
+
+<!-- README_FOOTER -->
+## Sponsors
+
+<!--
+Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [Become a sponsor](mailto:sponsor@webda.io)
+-->
+
+Arize AI is a machine learning observability and model monitoring platform. It helps you visualize, monitor, and explain your machine learning models. [Learn more](https://arize.com)
+
+[<img src="https://arize.com/hubfs/arize/brand/arize-logomark-1.png" width="200">](https://arize.com)
+
+Loopingz is a software development company that provides consulting and development services. [Learn more](https://loopingz.com)
+
+[<img src="https://loopingz.com/images/logo.png" width="200">](https://loopingz.com)
+
+Tellae is an innovative consulting firm specialized in cities transportation issues. We provide our clients, both public and private, with solutions to support your strategic and operational decisions. [Learn more](https://tellae.fr)
+
+[<img src="https://tellae.fr/" width="200">](https://tellae.fr)

--- a/packages/hawk/src/apikey.spec.ts
+++ b/packages/hawk/src/apikey.spec.ts
@@ -39,7 +39,7 @@ class ApiKeyTest extends WebdaSimpleTest {
   }
 
   @test
-  checkOrigin() {
+  async checkOrigin() {
     this.apikey.load(<any>KEY, true);
 
     this.getExecutor(this.context, "test.webda.io", "PUT", "/origins", {}, { origin: "https://test.webda.io/" });
@@ -49,11 +49,11 @@ class ApiKeyTest extends WebdaSimpleTest {
     assert.ok(this.apikey.checkOrigin(this.context.getHttpContext()), "localhost should be granted");
 
     this.getExecutor(this.context, "test.webda.io", "PUT", "/origins", {}, { origin: "https://localhost:18080/" });
-    assert.ok(!this.apikey.canRequest(this.context), "localhost https should be refused");
+    assert.ok(!await this.apikey.canRequest(this.context), "localhost https should be refused");
   }
 
   @test
-  checkWhitelist() {
+  async checkWhitelist() {
     this.apikey.load(
       <any>{
         ...KEY,
@@ -65,38 +65,38 @@ class ApiKeyTest extends WebdaSimpleTest {
 
     this.getExecutor(this.context, "test.webda.io", "PUT", "/path/to/the/valhalla");
     this.context.getHttpContext().setClientIp("127.0.0.1");
-    assert.ok(this.apikey.canRequest(this.context), "remotehost should be granted");
+    assert.ok(await this.apikey.canRequest(this.context), "remotehost should be granted");
     this.context.getHttpContext().setClientIp("127.0.0.2");
-    assert.ok(!this.apikey.canRequest(this.context), "127.0.0.2 should not be granted");
+    assert.ok(!(await this.apikey.canRequest(this.context)), "127.0.0.2 should not be granted");
     this.context.getHttpContext().setClientIp("10.0.0.1");
-    assert.ok(this.apikey.canRequest(this.context), "10.0.0.1 should be granted");
+    assert.ok(await this.apikey.canRequest(this.context), "10.0.0.1 should be granted");
     this.context.getHttpContext().setClientIp("10.1.0.1");
-    assert.ok(!this.apikey.canRequest(this.context), "10.1.0.1 should not be granted");
+    assert.ok(!(await this.apikey.canRequest(this.context)), "10.1.0.1 should not be granted");
   }
 
   @test
-  canRequestNoOrigin() {
+  async canRequestNoOrigin() {
     this.apikey.load(<any>{ ...KEY, origins: undefined }, true);
 
     this.getExecutor(this.context, "test.webda.io", "POST", "/path");
-    assert.ok(!this.apikey.canRequest(this.context), "POST should be false");
+    assert.ok(!await this.apikey.canRequest(this.context), "POST should be false");
 
     this.getExecutor(this.context, "test.webda.io", "PATCH", "/path/to/inferno");
-    assert.ok(!this.apikey.canRequest(this.context), "inferno should be false");
+    assert.ok(!(await this.apikey.canRequest(this.context)), "inferno should be false");
 
     this.getExecutor(this.context, "test.webda.io", "GET", "/path/to/the/valhalla");
-    assert.ok(!this.apikey.canRequest(this.context), "valhalla GET should be false");
+    assert.ok(!(await this.apikey.canRequest(this.context)), "valhalla GET should be false");
 
     this.getExecutor(this.context, "test.webda.io", "PUT", "/path/to/the/valhalla");
-    assert.ok(this.apikey.canRequest(this.context), "valhalla PUT should be granted");
+    assert.ok(await this.apikey.canRequest(this.context), "valhalla PUT should be granted");
   }
 
   @test
-  canRequestNoPermissions() {
+  async canRequestNoPermissions() {
     this.apikey.load({ ...KEY, origins: undefined, permissions: undefined }, true);
 
     this.getExecutor(this.context, "test.webda.io", "GET", "/path/to/the/valhalla");
-    assert.ok(this.apikey.canRequest(this.context), "no permissions should be true");
+    assert.ok(await this.apikey.canRequest(this.context), "no permissions should be true");
   }
 
   @test

--- a/packages/hawk/src/apikey.ts
+++ b/packages/hawk/src/apikey.ts
@@ -116,7 +116,7 @@ export default class ApiKey extends OwnerModel {
    * @param {HttpContext} ctx
    * @returns {boolean} TRUE if all key's contraints are authorized
    */
-  canRequest(context: WebContext): boolean {
+  async canRequest(context: WebContext): Promise<boolean> {
     const ctx = context.getHttpContext();
     if (!this.checkOrigin(ctx)) {
       return false;

--- a/packages/hawk/src/hawk.ts
+++ b/packages/hawk/src/hawk.ts
@@ -263,7 +263,7 @@ export default class HawkService extends Service<HawkServiceParameters> implemen
       try {
         context.setExtension("hawk", await Hawk.server.authenticate(hawkRequest, this.getApiKey.bind(this)));
         let fullKey = await this.model.ref(context.getExtension("hawk").credentials.id).get();
-        if (!fullKey.canRequest(context)) {
+        if (!(await fullKey.canRequest(context))) {
           throw new WebdaError.Forbidden("Key not allowed to request");
         }
       } catch (err) {

--- a/packages/postgres/README.md
+++ b/packages/postgres/README.md
@@ -1,0 +1,33 @@
+# @webda/postgres module
+
+This module is part of Webda Application Framework that allows you to quickly develop applications with all modern prerequisites: Security, Extensibility, GraphQL, REST, CloudNative [https://webda.io](https://webda.io)
+
+<img src="https://webda.io/images/webda.svg" width="128" />
+
+![CI](https://github.com/loopingz/webda.io/workflows/CI/badge.svg)
+
+[![Join the chat at https://gitter.im/loopingz/webda](https://badges.gitter.im/loopingz/webda.svg)](https://gitter.im/loopingz/webda?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![codecov](https://codecov.io/gh/loopingz/webda.io/branch/main/graph/badge.svg?token=8N9DNM3K3O)](https://codecov.io/gh/loopingz/webda.io)
+[![SonarCloud.io](https://sonarcloud.io/api/project_badges/measure?project=loopingz_webda.io&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=loopingz_webda.io)
+![CodeQL](https://github.com/loopingz/webda.io/workflows/CodeQL/badge.svg)
+
+<!-- README_HEADER -->
+
+<!-- README_FOOTER -->
+## Sponsors
+
+<!--
+Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [Become a sponsor](mailto:sponsor@webda.io)
+-->
+
+Arize AI is a machine learning observability and model monitoring platform. It helps you visualize, monitor, and explain your machine learning models. [Learn more](https://arize.com)
+
+[<img src="https://arize.com/hubfs/arize/brand/arize-logomark-1.png" width="200">](https://arize.com)
+
+Loopingz is a software development company that provides consulting and development services. [Learn more](https://loopingz.com)
+
+[<img src="https://loopingz.com/images/logo.png" width="200">](https://loopingz.com)
+
+Tellae is an innovative consulting firm specialized in cities transportation issues. We provide our clients, both public and private, with solutions to support your strategic and operational decisions. [Learn more](https://tellae.fr)
+
+[<img src="https://tellae.fr/" width="200">](https://tellae.fr)

--- a/packages/postgres/src/postgresstore.spec.ts
+++ b/packages/postgres/src/postgresstore.spec.ts
@@ -24,6 +24,17 @@ export class PostgresTest extends StoreTest {
   }
 
   @test
+  async correctEscape() {
+    const ident = <Store<Ident>>this.getIdentStore();
+    await ident.save({
+      name: "test"
+    });
+    assert.strictEqual((await Ident.query("name = 'test'")).results.length, 1);
+    await assert.rejects(() => Ident.query("name = '\"test'"), /SyntaxError/);
+    assert.strictEqual((await Ident.query('name = "\'test"')).results.length, 0);
+  }
+
+  @test
   async createTable() {
     const client = new pg.Client({
       host: "localhost",

--- a/packages/postgres/src/sqlstore.ts
+++ b/packages/postgres/src/sqlstore.ts
@@ -29,7 +29,7 @@ export interface SQLResult<T> {
 export class SQLComparisonExpression extends WebdaQL.ComparisonExpression {
   toStringValue(value: (string | number | boolean) | (string | number | boolean)[]): string {
     if (typeof value === "string") {
-      return `'${value}'`;
+      return `'${value.replace(/'/g, "''")}'`;
     }
     return super.toStringValue(value);
   }

--- a/packages/postgres/src/sqlstore.ts
+++ b/packages/postgres/src/sqlstore.ts
@@ -94,7 +94,7 @@ export abstract class SQLStore<T extends CoreModel, K extends SQLStoreParameters
     }
   }
 
-  abstract mapExpressionAttribute(attribute: string[]): string;
+  abstract mapExpressionAttribute(attribute: string[], asString?: boolean): string;
 
   duplicateExpression(expression: WebdaQL.Expression): WebdaQL.Expression {
     if (expression instanceof WebdaQL.AndExpression) {
@@ -112,7 +112,7 @@ export abstract class SQLStore<T extends CoreModel, K extends SQLStoreParameters
         return new SQLComparisonExpression(
           // Small hack
           <any>"?",
-          "(" + this.mapExpressionAttribute(expression.attribute) + ")::jsonb",
+          "(" + this.mapExpressionAttribute(expression.attribute, false) + ")",
           expression.value
         );
       }

--- a/packages/postgres/webda.module.json
+++ b/packages/postgres/webda.module.json
@@ -2363,6 +2363,11 @@
             ".*"
           ]
         },
+        "debug": {
+          "type": "boolean",
+          "description": "Call explain on each query to ensure it is optimized",
+          "default": false
+        },
         "openapi": {
           "type": "object",
           "additionalProperties": true


### PR DESCRIPTION
- **ci: enable on maintenance/v3**
- **fix: prometheus missing export and additional close**
- **ci: add maintenance/v3**
- **fix: prependQuery offset injection (#682)**
- **ci: update release please**
- **chore: update webda.module.json**
- **ci: fix target-branch**
- **ci: disable release-please on maintenance for now**
- **chore(release): @webda/core 3.16.1**
- **fix: restdomainservice parent query injector**
- **chore: release @webda/core 3.16.2**
- **fix: optimize webda.module.json search**
- **chore(deps): bump cookie from 0.6.0 to 1.0.1**
- **fix: module generation**
- **chore: update .gitignore**
- **chore(release): publish**
- **fix: ensure BinaryFileInfo**
- **chore(release): publish**
- **fix(async): service runner operation context**
- **fix(async): add servicerunner export**
- **chore(deps): bump nx**
- **test(core): fix async test**
- **feat: drop node 18**
- **fix: prevent canAct on non-CoreModel object**
- **fix(graphql): prevent parse error**
- **fix(async): prevent event stuck if action not found**
- **fix: s3 sdk putObject do not accept unknown length Readable anymore**
- **ci: add specific log**
- **fix: unit test**
- **fix: update webda.module.json**
- **chore(release): publish**
- **fix(webdaql): bad escape of ' and "**
