### PR TITLE
feat: blog admin web UI and HTTP pipeline improvements

### DIFF
--- a/packages/core/src/contexts/icontext.ts
+++ b/packages/core/src/contexts/icontext.ts
@@ -153,14 +153,25 @@ export abstract class Context {
     const isPipelineOptions = (arg: NodeJS.ReadWriteStream | PipelineOptions): arg is PipelineOptions =>
       (arg as NodeJS.ReadWriteStream).writable === undefined;
     const item = streams.pop();
-    if (item !== undefined && isPipelineOptions(item)) {
-      await pipeline([stream1, ...(<Array<NodeJS.ReadWriteStream>>streams), await this.getOutputStream()], item);
-    } else {
-      if (item !== undefined) {
-        streams.push(item);
+    const output = await this.getOutputStream();
+    // Use pipe() instead of stream/promises.pipeline() to avoid
+    // ERR_STREAM_PREMATURE_CLOSE unhandled rejections with ServerResponse
+    const allStreams: NodeJS.ReadWriteStream[] = item !== undefined && !isPipelineOptions(item)
+      ? [...(<Array<NodeJS.ReadWriteStream>>streams), item as NodeJS.ReadWriteStream]
+      : <Array<NodeJS.ReadWriteStream>>streams;
+    return new Promise<void>((resolve, reject) => {
+      let current: NodeJS.ReadableStream = stream1;
+      for (const transform of allStreams) {
+        current = (current as any).pipe(transform);
       }
-      await pipeline([stream1, ...(<Array<NodeJS.ReadWriteStream>>streams), await this.getOutputStream()]);
-    }
+      (current as any).pipe(output, { end: true });
+      stream1.on("error", reject);
+      output.on("error", (err: any) => {
+        if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") resolve();
+        else reject(err);
+      });
+      output.on("finish", resolve);
+    });
   }
 
   abstract getOutputStream(): Promise<Writable>;

--- a/packages/core/src/contexts/webcontext.ts
+++ b/packages/core/src/contexts/webcontext.ts
@@ -4,7 +4,7 @@ import * as http from "http";
 import { HttpContext } from "./httpcontext.js";
 import { Readable, Writable } from "node:stream";
 import { WritableStreamBuffer } from "stream-buffers";
-import { useCore, useService } from "../core/hooks.js";
+import { useCore, useDynamicService, useService } from "../core/hooks.js";
 
 /**
  * @category CoreFeatures
@@ -231,15 +231,28 @@ export class WebContext<T = any, P = any, U = any> extends OperationContext<T, P
       return this._ended;
     }
     this._ended = (async () => {
-      if (this.getExtension("http")) {
-        await useService("SessionManager").save(this, this.session);
+      if (this.getExtension("http") && this.session) {
+        try {
+          const sm = useDynamicService("SessionManager");
+          if (sm) await (sm as any).save(this, this.session);
+        } catch {
+          // SessionManager may not be available
+        }
       }
       await super.end();
       if (this._stream instanceof WritableStreamBuffer && (<WritableStreamBuffer>this._stream).size()) {
         this._body = (<WritableStreamBuffer>this._stream).getContents().toString();
         this.statusCode = this.statusCode < 300 ? 200 : this.statusCode;
       }
-      // TODO Handle the case where the headers were not flushed
+      // Flush headers and body to the HTTP response stream
+      await this.flushHeaders();
+      if (this._stream && !(this._stream instanceof WritableStreamBuffer) && !(this._stream as any).writableEnded) {
+        if (this._body) {
+          (this._stream as any).end(this._body);
+        } else {
+          (this._stream as any).end();
+        }
+      }
     })();
     return this._ended;
   }
@@ -325,6 +338,24 @@ export class WebContext<T = any, P = any, U = any> extends OperationContext<T, P
    */
   setFlushedHeaders(status: boolean = true) {
     this.headersFlushed = status;
+  }
+
+  /**
+   * Flush stored headers and status code to the underlying stream.
+   * For HTTP ServerResponse, writes via res.writeHead().
+   * Called automatically by getOutputStream() before pipeline() and by end().
+   */
+  async flushHeaders(): Promise<void> {
+    if (this.flushed) return;
+    // Merge both header maps — responseHeaders (from setHeader) + _outputHeaders (from constructor defaults)
+    const headers = { ...this._outputHeaders, ...this.getResponseHeaders() };
+    await super.flushHeaders();
+    // Write to ServerResponse if the stream supports writeHead (not a WritableStreamBuffer)
+    if (this._stream && !(this._stream instanceof WritableStreamBuffer) && typeof (this._stream as any).writeHead === "function") {
+      this.headersFlushed = true;
+      (this._stream as any).writeHead(this.statusCode || 200, headers);
+    }
+    this._outputHeaders = {};
   }
 
   /**

--- a/packages/core/src/services/httpserver.ts
+++ b/packages/core/src/services/httpserver.ts
@@ -6,6 +6,8 @@ import { Context, ContextProvider, ContextProviderInfo } from "../contexts/icont
 import { ServiceParameters } from "../services/serviceparameters.js";
 import { emitCoreEvent } from "../events/events.js";
 import { createServer, IncomingMessage, Server, ServerResponse } from "node:http";
+import { createServer as createHttpsServer } from "node:https";
+import { createSecureServer, Http2SecureServer } from "node:http2";
 import { HttpContext, HttpMethodType } from "../contexts/httpcontext.js";
 import { AddressInfo } from "node:net";
 import { createChecker } from "is-in-subnet";
@@ -14,8 +16,10 @@ import type { JSONed } from "@webda/models";
 import { Writable } from "node:stream";
 import { useRouter } from "../rest/hooks.js";
 import { runWithContext } from "../contexts/execution.js";
+import { readFileSync } from "node:fs";
+import { serialize as cookieSerialize } from "cookie";
 
-/** Parameters for the HTTP server including request limits, timeouts, and trusted proxy settings */
+/** Parameters for the HTTP server including request limits, timeouts, TLS, and proxy settings */
 export class HttpServerParameters extends ServiceParameters {
   /**
    * Will not try to parse request bigger than this
@@ -62,6 +66,20 @@ export class HttpServerParameters extends ServiceParameters {
   port?: number;
 
   /**
+   * TLS key file path — enables HTTPS or HTTP/2
+   */
+  key?: string;
+  /**
+   * TLS certificate file path
+   */
+  cert?: string;
+  /**
+   * Enable HTTP/2 (default: true when key+cert provided)
+   * Set to false for HTTPS without HTTP/2
+   */
+  http2?: boolean;
+
+  /**
    * Load parameters with defaults for request limits, timeouts, and proxy configuration
    * @param params - the service parameters
    * @returns this for chaining
@@ -79,28 +97,21 @@ export class HttpServerParameters extends ServiceParameters {
 }
 
 export type HttpServerEvents = {
-  /**
-   * Emitted when new result is sent
-   */
+  /** Emitted when new result is sent */
   "Webda.Result": { context: WebContext };
-  /**
-   * Emitted when new request comes in
-   */
+  /** Emitted when new request comes in */
   "Webda.Request": { context: WebContext };
-  /**
-   * Emitted when a request does not match any route
-   */
+  /** Emitted when a request does not match any route */
   "Webda.404": { context: WebContext };
-  /**
-   * Sent when route is added to context
-   */
-  "Webda.UpdateContextRoute": {
-    context: WebContext;
-  };
+  /** Sent when route is added to context */
+  "Webda.UpdateContextRoute": { context: WebContext };
 };
 
+/** HTTP/1.1-only headers that must be filtered for HTTP/2 */
+const HTTP1_ONLY_HEADERS = ["keep-alive", "connection", "transfer-encoding"];
+
 /**
- * Basic HTTP server service
+ * HTTP server service supporting HTTP/1.1, HTTPS, and HTTP/2
  *
  * @WebdaModda
  */
@@ -108,13 +119,10 @@ export class HttpServer<
   P extends HttpServerParameters = HttpServerParameters,
   E extends HttpServerEvents = HttpServerEvents
 > extends Service<P, E> {
-  /**
-   * Registered context providers
-   */
+  /** Registered context providers */
   private contextProviders: ContextProvider[] = [
     {
       getContext: (info: ContextProviderInfo) => {
-        // If http is defined, return a WebContext
         if (info.http) {
           return new WebContext(info.http, info.stream);
         }
@@ -122,64 +130,163 @@ export class HttpServer<
       }
     }
   ];
-  server: Server;
+  server: Server | Http2SecureServer;
   protected subnetChecker: (address: string) => boolean;
+  /** Whether this server uses HTTP/2 */
+  protected isHttp2 = false;
 
   /**
-   * Start the HTTP server, handling incoming requests and routing them through Webda
+   * Flush response headers from WebContext to the underlying response stream.
+   * Handles both HTTP/1.1 (writeHead) and HTTP/2 (setHeader + statusCode) patterns.
+   *
+   * @param ctx - the web context with stored headers
+   */
+  flushHeaders(ctx: WebContext): void {
+    const res = ctx._stream as ServerResponse;
+    if (res.headersSent) return;
+
+    const headers = { ...ctx["_outputHeaders"], ...ctx.getResponseHeaders() };
+    const cookies = ctx.getResponseCookies?.() || {};
+
+    if (this.isHttp2) {
+      // HTTP/2: use setHeader individually, filter HTTP/1.1-only headers
+      for (const [name, value] of Object.entries(headers)) {
+        if (HTTP1_ONLY_HEADERS.includes(name.toLowerCase())) continue;
+        res.setHeader(name, value as string | string[]);
+      }
+      for (const i in cookies) {
+        res.setHeader("Set-Cookie", cookieSerialize(cookies[i].name, cookies[i].value, cookies[i].options));
+      }
+      res.statusCode = ctx.getResponseCode();
+    } else {
+      // HTTP/1.1: use writeHead
+      for (const i in cookies) {
+        headers["Set-Cookie"] = cookieSerialize(cookies[i].name, cookies[i].value, cookies[i].options);
+      }
+      res.writeHead(ctx.getResponseCode(), headers);
+    }
+  }
+
+  /**
+   * Flush the response body and close the response.
+   *
+   * @param ctx - the web context with buffered output
+   */
+  flush(ctx: WebContext): void {
+    const res = ctx._stream as ServerResponse;
+    if (res.writableEnded) return;
+    this.flushHeaders(ctx);
+    res.end(ctx.getOutput() || "");
+  }
+
+  /**
+   * Handle an incoming HTTP request: create context, route, flush response.
+   *
+   * @param req - the incoming message
+   * @param res - the server response
+   */
+  async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const ctx = await this.getContextFromRequest(req, res);
+      if (!ctx) {
+        res.writeHead(500);
+        res.end();
+        return;
+      }
+      const webCtx = ctx as WebContext;
+      await runWithContext(webCtx, async () => {
+        try {
+          try { emitCoreEvent("Webda.Request", { context: webCtx }); } catch { /* listener error */ }
+          await useRouter().execute(webCtx);
+          try { emitCoreEvent("Webda.Result", { context: webCtx }); } catch { /* listener error */ }
+        } catch (err) {
+          webCtx.statusCode = err?.getResponseCode?.() || 500;
+        }
+      });
+      // Flush response — skip if pipeline/streaming already handled it
+      if (!res.writableEnded && !res.headersSent) {
+        this.flush(webCtx);
+      } else if (!res.writableEnded) {
+        // Headers sent (by flushHeaders in pipeline path) but body not ended
+        res.end(webCtx.getOutput() || "");
+      }
+    } catch (err) {
+      if (!res.writableEnded) {
+        if (!res.headersSent) res.writeHead(500);
+        res.end();
+      }
+    }
+  }
+
+  /**
+   * Start the HTTP server
    * @param bind - the bind address
    * @param port - the port number
-   * @returns the result
    */
   @Command("serve", { description: "Start the HTTP server", requires: ["router", "rest-domain"] })
   async serve(bind?: string, port?: number) {
-    return this.parameters.with(async params => {
-      useLog("INFO", `Starting HTTP server on ${bind ?? "0.0.0.0"}:${port ?? params.port ?? 18080}`);
-      if (this.server) {
-        await new Promise(resolve => this.server.close(resolve));
+    this.parameters.with(params => {
+      const listenPort = port || params.port || 18080;
+      useLog("INFO", `Starting HTTP server on ${bind ?? "0.0.0.0"}:${listenPort}`);
+
+      // Node.js pipeline() emits ERR_STREAM_PREMATURE_CLOSE as uncaughtException
+      // when piping to ServerResponse. Suppress this specific error.
+      if (!process.listeners("uncaughtExceptionMonitor").find((l: any) => l._webda)) {
+        const monitor = function _webdaMonitor() {};
+        (monitor as any)._webda = true;
+        process.on("uncaughtExceptionMonitor", monitor);
       }
-      // Suppress stream pipeline close errors (client disconnect mid-stream)
-      if (!process.listeners("unhandledRejection").find((l: any) => l._webdaHttpServer)) {
+      if (!process.listeners("uncaughtException").find((l: any) => l._webda)) {
         const handler = function _webdaHandler(err: any) {
           if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") return;
-          throw err;
+          useLog("ERROR", "Uncaught exception", err);
+          process.exit(1);
         };
-        (handler as any)._webdaHttpServer = true;
-        process.on("unhandledRejection", handler);
+        (handler as any)._webda = true;
+        process.on("uncaughtException", handler);
       }
-      this.server = createServer(async (req, res) => {
-        try {
-          const ctx = await this.getContextFromRequest(req, res);
-          if (!ctx) {
-            res.writeHead(500);
-            res.end();
-            return;
-          }
-          const webCtx = ctx as WebContext;
-          await runWithContext(webCtx, async () => {
-            try {
-              try { emitCoreEvent("Webda.Request", { context: webCtx }); } catch { /* event listener error */ }
-              await useRouter().execute(webCtx);
-              try { emitCoreEvent("Webda.Result", { context: webCtx }); } catch { /* event listener error */ }
-            } catch (err) {
-              webCtx.statusCode = err?.getResponseCode?.() || 500;
+
+
+      if (this.server) {
+        this.server.close();
+      }
+
+      // Create server based on TLS configuration
+      if (params.key && params.cert) {
+        const tlsOptions = {
+          key: readFileSync(params.key),
+          cert: readFileSync(params.cert),
+          allowHTTP1: true
+        };
+        if (params.http2 !== false) {
+          // HTTP/2 with HTTP/1.1 fallback
+          this.isHttp2 = true;
+          this.server = createSecureServer(tlsOptions, (req, res) => {
+            // Filter HTTP/2 pseudo-headers for compatibility
+            if (req.headers[":authority"]) {
+              const [host] = (req.headers[":authority"] as string).split(":");
+              req.headers.host = host;
             }
+            this.handleRequest(req as any, res as any);
           });
-          // WebContext.end() flushes headers + body to the ServerResponse
-          await webCtx.end();
-        } catch (err) {
-          // Ensure the response is always closed
-          if (!res.writableEnded) {
-            if (!res.headersSent) res.writeHead(500);
-            res.end();
-          }
+        } else {
+          // HTTPS without HTTP/2
+          this.server = createHttpsServer(tlsOptions, (req, res) => this.handleRequest(req, res));
         }
-      });
+      } else {
+        // Plain HTTP/1.1
+        this.server = createServer((req, res) => this.handleRequest(req, res));
+      }
+
       // Ensure routes are mapped before accepting requests
       useRouter().remapRoutes();
-      this.server.listen(port || params.port || 18080);
+      this.server.listen(listenPort, bind);
+
+      // Emit event for WebSocket upgrade handling (used by GraphQL subscriptions)
+      this.emit("Webda.Init.Http" as any, this.server as any);
     });
-    // We do not want to stop server if other params are changed
+
+    // Set up trusted proxy checker
     this.parameters.with(params => {
       this.subnetChecker = createChecker(
         params.trustedProxies.map(n => (n.indexOf("/") < 0 ? `${n.trim()}/32` : n.trim()))
@@ -187,47 +294,43 @@ export class HttpServer<
     });
   }
 
-  /**
-   * @override
-   */
+  /** @override */
   async stop(): Promise<void> {
     await super.stop();
     this.server?.close();
   }
 
   /**
-   * Return a Context object based on a request
-   * @param req to initiate object from
-   * @param res to add for body
-   * @returns the result
+   * Create a WebContext from an HTTP request
+   * @param req - the incoming message
+   * @param res - the server response
+   * @returns the context, or undefined if request should be rejected
    */
   async getContextFromRequest(req: IncomingMessage, res?: ServerResponse) {
-    // Handle reverse proxy
-    let vhost: string = req.headers.host.match(/:/g)
+    let vhost: string = req.headers.host?.match(/:/g)
       ? req.headers.host.slice(0, req.headers.host.indexOf(":"))
-      : req.headers.host;
+      : req.headers.host || "localhost";
+
     if (
       (req.headers["x-forwarded-for"] ||
         req.headers["x-forwarded-host"] ||
         req.headers["x-forwarded-proto"] ||
         req.headers["x-forwarded-port"]) &&
-      !this.isProxyTrusted(req.socket.remoteAddress)
+      !this.isProxyTrusted(req.socket?.remoteAddress)
     ) {
-      // Do not even let the query go through
-      this.log("WARN", `X-Forwarded-* headers set from an unknown source: ${req.socket.remoteAddress}`);
-      res.writeHead(400);
+      this.log("WARN", `X-Forwarded-* headers set from an unknown source: ${req.socket?.remoteAddress}`);
+      res?.writeHead(400);
       return;
     }
-    // Might want to add some whitelisting
+
     if (req.headers["x-forwarded-host"] !== undefined) {
       vhost = <string>req.headers["x-forwarded-host"];
     }
-    let protocol: "http" | "https" = "http";
+    let protocol: "http" | "https" = this.isHttp2 ? "https" : "http";
     if (req.headers["x-forwarded-proto"] !== undefined) {
       protocol = <"http" | "https">req.headers["x-forwarded-proto"];
     }
 
-    const method = req.method;
     let port;
     if (req.socket && req.socket.address()) {
       port = (<AddressInfo>req.socket.address()).port;
@@ -235,13 +338,18 @@ export class HttpServer<
     if (req.headers["x-forwarded-port"] !== undefined) {
       port = parseInt(<string>req.headers["x-forwarded-port"]);
     } else if (req.headers["x-forwarded-proto"] !== undefined) {
-      // GCP send a proto without port so fallback on default port
       port = protocol === "http" ? 80 : 443;
     }
-    const httpContext = new HttpContext(vhost, <HttpMethodType>method, req.url, protocol, port, req.headers);
-    httpContext.setClientIp(httpContext.getUniqueHeader("x-forwarded-for", req.socket.remoteAddress));
-    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
-    if (["PUT", "PATCH", "POST", "DELETE"].includes(method)) {
+
+    // Filter HTTP/2 pseudo-headers from the headers object
+    const headers = this.isHttp2
+      ? Object.fromEntries(Object.entries(req.headers).filter(([k]) => !k.startsWith(":")))
+      : req.headers;
+
+    const httpContext = new HttpContext(vhost, <HttpMethodType>req.method, req.url, protocol, port, headers as any);
+    httpContext.setClientIp(httpContext.getUniqueHeader("x-forwarded-for", req.socket?.remoteAddress));
+
+    if (["PUT", "PATCH", "POST", "DELETE"].includes(req.method)) {
       httpContext.setBody(req);
     }
     return this.newContext({ http: httpContext, stream: <Writable>res });
@@ -250,19 +358,17 @@ export class HttpServer<
   /**
    * Check if a proxy is a trusted proxy
    * @param ip - the IP address
-   * @returns true if the condition is met
+   * @returns true if the proxy is trusted
    */
   isProxyTrusted(ip: string): boolean {
-    // ipv4 mapped to v6
-    return this.subnetChecker(ip);
+    return this.subnetChecker?.(ip) ?? false;
   }
 
   /**
-   * Get a context based on the info
-   * @param info - the information object
-   * @returns the result
-   * @param noInit - whether to skip initialization
-   * @TODO Move to the HttpServer service
+   * Create a context from provider info
+   * @param info - the context provider info
+   * @param noInit - skip initialization
+   * @returns the created context
    */
   async newContext<T extends Context>(info: ContextProviderInfo, noInit: boolean = false): Promise<Context> {
     let context: Context;
@@ -275,9 +381,8 @@ export class HttpServer<
   }
 
   /**
-   * Register a new context provider
-   * @param provider - the provider name
-   * @TODO Move to the HttpServer service
+   * Register a new context provider (prepended, higher priority)
+   * @param provider - the context provider
    */
   registerContextProvider(provider: ContextProvider) {
     this.contextProviders ??= [];

--- a/packages/core/src/services/httpserver.ts
+++ b/packages/core/src/services/httpserver.ts
@@ -158,9 +158,9 @@ export class HttpServer<
           const webCtx = ctx as WebContext;
           await runWithContext(webCtx, async () => {
             try {
-              await emitCoreEvent("Webda.Request", { context: webCtx });
+              try { emitCoreEvent("Webda.Request", { context: webCtx }); } catch { /* event listener error */ }
               await useRouter().execute(webCtx);
-              await emitCoreEvent("Webda.Result", { context: webCtx });
+              try { emitCoreEvent("Webda.Result", { context: webCtx }); } catch { /* event listener error */ }
             } catch (err) {
               webCtx.statusCode = err?.getResponseCode?.() || 500;
             }

--- a/packages/core/src/services/httpserver.ts
+++ b/packages/core/src/services/httpserver.ts
@@ -138,6 +138,15 @@ export class HttpServer<
       if (this.server) {
         await new Promise(resolve => this.server.close(resolve));
       }
+      // Suppress stream pipeline close errors (client disconnect mid-stream)
+      if (!process.listeners("unhandledRejection").find((l: any) => l._webdaHttpServer)) {
+        const handler = function _webdaHandler(err: any) {
+          if (err?.code === "ERR_STREAM_PREMATURE_CLOSE") return;
+          throw err;
+        };
+        (handler as any)._webdaHttpServer = true;
+        process.on("unhandledRejection", handler);
+      }
       this.server = createServer(async (req, res) => {
         try {
           const ctx = await this.getContextFromRequest(req, res);
@@ -156,22 +165,14 @@ export class HttpServer<
               webCtx.statusCode = err?.getResponseCode?.() || 500;
             }
           });
-          // Flush headers and body to the HTTP response
-          if (!res.headersSent) {
-            res.writeHead(webCtx.statusCode || 200, webCtx.getResponseHeaders());
-          }
-          const body = webCtx.getOutput();
-          if (body) {
-            res.end(body);
-          } else {
-            res.end();
-          }
+          // WebContext.end() flushes headers + body to the ServerResponse
+          await webCtx.end();
         } catch (err) {
           // Ensure the response is always closed
-          if (!res.headersSent) {
-            res.writeHead(500);
+          if (!res.writableEnded) {
+            if (!res.headersSent) res.writeHead(500);
+            res.end();
           }
-          res.end();
         }
       });
       // Ensure routes are mapped before accepting requests

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -12,12 +12,18 @@
     "lint:fix": "eslint --fix src/"
   },
   "dependencies": {
-    "@webda/core": "^4.0.0-beta.1",
-    "@webda/workout": "^4.0.0-beta.1",
+    "@webda/workout": "workspace:*",
     "@grpc/proto-loader": "^0.7.0"
   },
+  "peerDependencies": {
+    "@webda/core": "^4.0.0-beta.1"
+  },
   "devDependencies": {
-    "@webda/test": "^4.0.0-beta.1",
+    "@webda/compiler": "workspace:^",
+    "@webda/core": "workspace:^",
+    "@webda/test": "workspace:^",
+    "@vitest/coverage-v8": "^4.1.2",
+    "vite": "^6.0.0",
     "vitest": "^4.0.0"
   },
   "webda": {

--- a/packages/grpc/package.json
+++ b/packages/grpc/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@webda/grpc",
+  "version": "4.0.0-beta.1",
+  "description": "gRPC transport for Webda.io — exposes operations as gRPC services",
+  "type": "module",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "webdac build",
+    "test": "vitest run",
+    "lint": "eslint src/",
+    "lint:fix": "eslint --fix src/"
+  },
+  "dependencies": {
+    "@webda/core": "^4.0.0-beta.1",
+    "@webda/workout": "^4.0.0-beta.1",
+    "@grpc/proto-loader": "^0.7.0"
+  },
+  "devDependencies": {
+    "@webda/test": "^4.0.0-beta.1",
+    "vitest": "^4.0.0"
+  },
+  "webda": {
+    "namespace": "Webda",
+    "capabilities": {
+      "grpc": "Webda/GrpcService"
+    }
+  },
+  "license": "LGPL-3.0-only",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/loopingz/webda.io.git",
+    "directory": "packages/grpc"
+  }
+}

--- a/packages/grpc/src/grpc-stream.spec.ts
+++ b/packages/grpc/src/grpc-stream.spec.ts
@@ -1,0 +1,417 @@
+import { suite, test } from "@webda/test";
+import * as assert from "assert";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { GrpcStream, GrpcStatus, GrpcMethodDef } from "./grpc-stream.js";
+
+/**
+ * Create a mock IncomingMessage-like object (EventEmitter + readable stream)
+ */
+function createMockRequest(): EventEmitter & { headers: Record<string, string> } {
+  const req = new PassThrough() as any;
+  req.headers = { "content-type": "application/grpc" };
+  return req;
+}
+
+/**
+ * Create a mock ServerResponse-like object that captures writes and trailers
+ */
+function createMockResponse(): {
+  res: any;
+  written: Buffer[];
+  headers: Record<string, string>;
+  trailers: Record<string, string> | null;
+  ended: boolean;
+} {
+  const state = {
+    written: [] as Buffer[],
+    headers: {} as Record<string, string>,
+    trailers: null as Record<string, string> | null,
+    ended: false,
+    res: null as any
+  };
+
+  state.res = {
+    setHeader(key: string, value: string) {
+      state.headers[key] = value;
+    },
+    write(data: Buffer) {
+      state.written.push(Buffer.from(data));
+    },
+    addTrailers(t: Record<string, string>) {
+      state.trailers = t;
+    },
+    end() {
+      state.ended = true;
+    }
+  };
+
+  return state;
+}
+
+/**
+ * Create a simple JSON-based method definition for testing
+ */
+function createJsonMethodDef(): GrpcMethodDef<any, any> {
+  return {
+    requestSerialize: (msg: any) => Buffer.from(JSON.stringify(msg)),
+    requestDeserialize: (buf: Buffer) => JSON.parse(buf.toString()),
+    responseSerialize: (msg: any) => Buffer.from(JSON.stringify(msg)),
+    responseDeserialize: (buf: Buffer) => JSON.parse(buf.toString()),
+    requestStream: false,
+    responseStream: false
+  };
+}
+
+/**
+ * Create a gRPC frame from a message buffer
+ * Format: 1 byte compressed flag + 4 bytes big-endian length + payload
+ */
+function createGrpcFrame(data: Buffer): Buffer {
+  const frame = Buffer.alloc(5 + data.length);
+  frame.writeUInt8(0, 0); // Not compressed
+  frame.writeUInt32BE(data.length, 1);
+  data.copy(frame, 5);
+  return frame;
+}
+
+@suite
+class GrpcStreamTest {
+  @test
+  constructorSetsHeaders() {
+    const req = createMockRequest();
+    const { res, headers } = createMockResponse();
+    const def = createJsonMethodDef();
+
+    new GrpcStream(req as any, res, def);
+
+    assert.strictEqual(headers["Content-Type"], "application/grpc");
+    assert.strictEqual(headers["Grpc-Accept-Encoding"], "identity");
+    assert.strictEqual(headers["Grpc-Encoding"], "identity");
+  }
+
+  @test
+  async onMessageReceivesDeserializedMessage() {
+    const req = createMockRequest();
+    const { res } = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, res, def);
+
+    const received: any[] = [];
+    stream.onMessage(msg => {
+      received.push(msg);
+    });
+
+    const payload = Buffer.from(JSON.stringify({ hello: "world" }));
+    const frame = createGrpcFrame(payload);
+    req.emit("data", frame);
+
+    assert.strictEqual(received.length, 1);
+    assert.deepStrictEqual(received[0], { hello: "world" });
+  }
+
+  @test
+  async sendCreatesProperGrpcFrame() {
+    const req = createMockRequest();
+    const { res, written } = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, res, def);
+
+    stream.send({ result: "ok" });
+
+    assert.strictEqual(written.length, 1);
+    const frame = written[0];
+
+    // Verify frame structure: 1 byte compression + 4 bytes length + payload
+    assert.strictEqual(frame.readUInt8(0), 0, "Compression flag should be 0");
+    const payloadLength = frame.readUInt32BE(1);
+    const payload = frame.subarray(5, 5 + payloadLength);
+    const decoded = JSON.parse(payload.toString());
+    assert.deepStrictEqual(decoded, { result: "ok" });
+  }
+
+  @test
+  async endWritesTrailersWithGrpcStatus() {
+    const req = createMockRequest();
+    const { res, trailers, ended } = createMockResponse();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    stream.end(0);
+
+    assert.ok(mock.ended, "Response should be ended");
+    assert.ok(mock.trailers !== null, "Trailers should be set");
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+    assert.strictEqual(mock.trailers!["grpc-message"], undefined, "No message for OK status");
+  }
+
+  @test
+  async endWithMessageEncodesURIComponent() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    stream.end(13, "Internal server error");
+
+    assert.ok(mock.trailers !== null);
+    assert.strictEqual(mock.trailers!["grpc-status"], "13");
+    assert.strictEqual(mock.trailers!["grpc-message"], encodeURIComponent("Internal server error"));
+  }
+
+  @test
+  async endDefaultStatusIsZero() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    stream.end(); // No arguments
+
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async sendUnarySendsMessageThenEnds() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    stream.sendUnary({ data: "response" });
+
+    // Should have written one frame
+    assert.strictEqual(mock.written.length, 1);
+    const payload = mock.written[0].subarray(5);
+    assert.deepStrictEqual(JSON.parse(payload.toString()), { data: "response" });
+
+    // Should have ended with status 0
+    assert.ok(mock.ended);
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async sendErrorEndsWithErrorStatus() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    stream.sendError(GrpcStatus.NOT_FOUND, "Resource not found");
+
+    assert.ok(mock.ended);
+    assert.strictEqual(mock.trailers!["grpc-status"], "5");
+    assert.strictEqual(mock.trailers!["grpc-message"], encodeURIComponent("Resource not found"));
+    // Should NOT have written any data frames
+    assert.strictEqual(mock.written.length, 0);
+  }
+
+  @test
+  async multipleMessagesInOneChunk() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    const received: any[] = [];
+    stream.onMessage(msg => {
+      received.push(msg);
+    });
+
+    const payload1 = Buffer.from(JSON.stringify({ id: 1 }));
+    const payload2 = Buffer.from(JSON.stringify({ id: 2 }));
+    const frame1 = createGrpcFrame(payload1);
+    const frame2 = createGrpcFrame(payload2);
+
+    // Send both frames in a single data event
+    const combined = Buffer.concat([frame1, frame2]);
+    req.emit("data", combined);
+
+    assert.strictEqual(received.length, 2);
+    assert.deepStrictEqual(received[0], { id: 1 });
+    assert.deepStrictEqual(received[1], { id: 2 });
+  }
+
+  @test
+  async splitChunksPartialMessage() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    const received: any[] = [];
+    stream.onMessage(msg => {
+      received.push(msg);
+    });
+
+    const payload = Buffer.from(JSON.stringify({ key: "value" }));
+    const frame = createGrpcFrame(payload);
+
+    // Split the frame at an arbitrary point (midway through the payload)
+    const splitPoint = 8; // After header + a few bytes of payload
+    const part1 = frame.subarray(0, splitPoint);
+    const part2 = frame.subarray(splitPoint);
+
+    // Emit first part — incomplete message
+    req.emit("data", part1);
+    assert.strictEqual(received.length, 0, "Should not deliver incomplete message");
+
+    // Emit second part — completes the message
+    req.emit("data", part2);
+    assert.strictEqual(received.length, 1, "Should deliver message after all parts arrive");
+    assert.deepStrictEqual(received[0], { key: "value" });
+  }
+
+  @test
+  async onEndHandlerCalledWhenRequestEnds() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    let endCalled = false;
+    stream.onEnd(() => {
+      endCalled = true;
+    });
+
+    req.emit("end");
+
+    assert.ok(endCalled, "onEnd handler should be called");
+  }
+
+  @test
+  async onCancelHandlerCalledWhenRequestCloses() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    let cancelCalled = false;
+    stream.onCancel(() => {
+      cancelCalled = true;
+    });
+
+    req.emit("close");
+
+    assert.ok(cancelCalled, "onCancel handler should be called");
+  }
+
+  @test
+  chainingReturnsSameInstance() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    const stream = new GrpcStream(req as any, mock.res, def);
+
+    const result = stream
+      .onMessage(() => {})
+      .onEnd(() => {})
+      .onCancel(() => {});
+
+    assert.strictEqual(result, stream, "Chaining methods should return the same instance");
+  }
+
+  @test
+  async endHandlesResponseWithoutAddTrailers() {
+    const req = createMockRequest();
+    const def = createJsonMethodDef();
+
+    // Create a response that does NOT have addTrailers
+    const res = {
+      setHeader() {},
+      write() {},
+      end() {}
+      // no addTrailers
+    };
+
+    const stream = new GrpcStream(req as any, res as any, def);
+
+    // Should not throw even without addTrailers
+    stream.end(0);
+  }
+
+  @test
+  async noMessageHandlerDoesNotThrow() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    // Create stream without registering onMessage
+    new GrpcStream(req as any, mock.res, def);
+
+    const payload = Buffer.from(JSON.stringify({ test: true }));
+    const frame = createGrpcFrame(payload);
+
+    // Should not throw when no handler is registered
+    req.emit("data", frame);
+  }
+
+  @test
+  async noEndHandlerDoesNotThrow() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    // No onEnd registered
+    new GrpcStream(req as any, mock.res, def);
+
+    // Should not throw
+    req.emit("end");
+  }
+
+  @test
+  async noCancelHandlerDoesNotThrow() {
+    const req = createMockRequest();
+    const mock = createMockResponse();
+    const def = createJsonMethodDef();
+
+    // No onCancel registered
+    new GrpcStream(req as any, mock.res, def);
+
+    // Should not throw
+    req.emit("close");
+  }
+}
+
+@suite
+class GrpcStatusTest {
+  @test
+  statusCodeValues() {
+    assert.strictEqual(GrpcStatus.OK, 0);
+    assert.strictEqual(GrpcStatus.CANCELLED, 1);
+    assert.strictEqual(GrpcStatus.UNKNOWN, 2);
+    assert.strictEqual(GrpcStatus.INVALID_ARGUMENT, 3);
+    assert.strictEqual(GrpcStatus.DEADLINE_EXCEEDED, 4);
+    assert.strictEqual(GrpcStatus.NOT_FOUND, 5);
+    assert.strictEqual(GrpcStatus.ALREADY_EXISTS, 6);
+    assert.strictEqual(GrpcStatus.PERMISSION_DENIED, 7);
+    assert.strictEqual(GrpcStatus.RESOURCE_EXHAUSTED, 8);
+    assert.strictEqual(GrpcStatus.FAILED_PRECONDITION, 9);
+    assert.strictEqual(GrpcStatus.ABORTED, 10);
+    assert.strictEqual(GrpcStatus.OUT_OF_RANGE, 11);
+    assert.strictEqual(GrpcStatus.UNIMPLEMENTED, 12);
+    assert.strictEqual(GrpcStatus.INTERNAL, 13);
+    assert.strictEqual(GrpcStatus.UNAVAILABLE, 14);
+    assert.strictEqual(GrpcStatus.DATA_LOSS, 15);
+    assert.strictEqual(GrpcStatus.UNAUTHENTICATED, 16);
+  }
+
+  @test
+  okSymbol() {
+    assert.ok(typeof GrpcStream.OK === "symbol", "OK should be a symbol");
+    assert.strictEqual(GrpcStream.OK.toString(), "Symbol(OK)");
+  }
+}

--- a/packages/grpc/src/grpc-stream.ts
+++ b/packages/grpc/src/grpc-stream.ts
@@ -1,0 +1,192 @@
+import type { Http2ServerRequest, Http2ServerResponse } from "node:http2";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Parsed gRPC method definition with serializer/deserializer functions.
+ */
+export interface GrpcMethodDef<Req = any, Res = any> {
+  requestSerialize: (msg: Req) => Buffer;
+  requestDeserialize: (buf: Buffer) => Req;
+  responseSerialize: (msg: Res) => Buffer;
+  responseDeserialize: (buf: Buffer) => Res;
+  requestStream: boolean;
+  responseStream: boolean;
+}
+
+/**
+ * gRPC bidirectional stream handler.
+ *
+ * Manages frame parsing (5-byte header: compressed flag + 4-byte big-endian length),
+ * message deserialization, and response framing for HTTP/2 gRPC streams.
+ *
+ * Supports all four gRPC patterns:
+ * - Unary (single request, single response)
+ * - Server streaming (single request, stream of responses)
+ * - Client streaming (stream of requests, single response)
+ * - Bidirectional streaming (stream of requests, stream of responses)
+ */
+export class GrpcStream<RequestType = any, ResponseType = any> {
+  /** Sentinel value indicating successful stream setup */
+  static OK = Symbol("OK");
+
+  private onMessageHandler: (message: RequestType) => void | Promise<void>;
+  private onEndHandler?: () => void;
+  private onCancelHandler?: () => void;
+  private chunk: Buffer | null = null;
+  private messageLength = 0;
+  private request: IncomingMessage | Http2ServerRequest;
+  private response: ServerResponse | Http2ServerResponse;
+  private definition: GrpcMethodDef<RequestType, ResponseType>;
+
+  /**
+   * Create a new GrpcStream to handle a single gRPC request/response lifecycle.
+   * @param req - the incoming HTTP/2 request carrying the gRPC frames
+   * @param res - the HTTP/2 response used to write gRPC frames and trailers
+   * @param definition - protobuf method definition providing serialize/deserialize functions
+   */
+  constructor(
+    req: IncomingMessage | Http2ServerRequest,
+    res: ServerResponse | Http2ServerResponse,
+    definition: GrpcMethodDef<RequestType, ResponseType>
+  ) {
+    this.request = req;
+    this.response = res;
+    this.definition = definition;
+
+    // Set gRPC response headers
+    this.response.setHeader("Content-Type", "application/grpc");
+    this.response.setHeader("Grpc-Accept-Encoding", "identity");
+    this.response.setHeader("Grpc-Encoding", "identity");
+
+    // Parse incoming gRPC frames
+    req.on("data", (data: Buffer) => {
+      if (this.chunk === null) {
+        this.messageLength = data.readUInt32BE(1);
+        this.chunk = data;
+      } else {
+        this.chunk = Buffer.concat([this.chunk, data]);
+      }
+      // Check if we have a complete message
+      while (this.chunk && this.chunk.length >= 5 + this.messageLength) {
+        const message = this.chunk.subarray(5, 5 + this.messageLength);
+        const deserialized = this.definition.requestDeserialize(message);
+        this.onMessageHandler?.(deserialized);
+        // Advance to next frame
+        this.chunk = this.chunk.subarray(5 + this.messageLength);
+        if (this.chunk.length >= 5) {
+          this.messageLength = this.chunk.readUInt32BE(1);
+        } else if (this.chunk.length === 0) {
+          this.chunk = null;
+        }
+      }
+    });
+
+    req.on("end", () => {
+      this.onEndHandler?.();
+    });
+
+    req.on("close", () => {
+      this.onCancelHandler?.();
+    });
+  }
+
+  /**
+   * Register handler for incoming messages
+   * @param handler - callback invoked with each deserialized request message
+   * @returns this instance for chaining
+   */
+  onMessage(handler: (message: RequestType) => void | Promise<void>): this {
+    this.onMessageHandler = handler;
+    return this;
+  }
+
+  /**
+   * Register handler for stream end (client finished sending)
+   * @param handler - callback invoked when the client closes the send side of the stream
+   * @returns this instance for chaining
+   */
+  onEnd(handler: () => void): this {
+    this.onEndHandler = handler;
+    return this;
+  }
+
+  /**
+   * Register handler for stream cancellation (client disconnected)
+   * @param handler - callback invoked when the underlying connection is closed by the client
+   * @returns this instance for chaining
+   */
+  onCancel(handler: () => void): this {
+    this.onCancelHandler = handler;
+    return this;
+  }
+
+  /**
+   * Send a response message with gRPC framing.
+   * @param message - the response message to serialize and send
+   * @returns void
+   */
+  send(message: ResponseType): void {
+    const responseBuffer = this.definition.responseSerialize(message);
+    const frame = Buffer.alloc(5 + responseBuffer.length);
+    frame.writeUInt8(0, 0); // Not compressed
+    frame.writeUInt32BE(responseBuffer.length, 1);
+    responseBuffer.copy(frame, 5);
+    this.response.write(frame);
+  }
+
+  /**
+   * End the response with gRPC status trailers.
+   * @param status - gRPC status code (0 = OK)
+   * @param message - optional status message included in grpc-message trailer
+   * @returns void
+   */
+  end(status: number = 0, message?: string): void {
+    const trailers: Record<string, string> = { "grpc-status": String(status) };
+    if (message) {
+      trailers["grpc-message"] = encodeURIComponent(message);
+    }
+    (this.response as any).addTrailers?.(trailers);
+    this.response.end();
+  }
+
+  /**
+   * Send a single unary response and close the stream.
+   * @param message - the response message to serialize and send before closing
+   * @returns void
+   */
+  sendUnary(message: ResponseType): void {
+    this.send(message);
+    this.end(0);
+  }
+
+  /**
+   * Send an error response and close the stream.
+   * @param status - gRPC status code indicating the error type
+   * @param message - human-readable error message included in grpc-message trailer
+   * @returns void
+   */
+  sendError(status: number, message: string): void {
+    this.end(status, message);
+  }
+}
+
+/** gRPC status codes */
+export const GrpcStatus = {
+  OK: 0,
+  CANCELLED: 1,
+  UNKNOWN: 2,
+  INVALID_ARGUMENT: 3,
+  DEADLINE_EXCEEDED: 4,
+  NOT_FOUND: 5,
+  ALREADY_EXISTS: 6,
+  PERMISSION_DENIED: 7,
+  RESOURCE_EXHAUSTED: 8,
+  FAILED_PRECONDITION: 9,
+  ABORTED: 10,
+  OUT_OF_RANGE: 11,
+  UNIMPLEMENTED: 12,
+  INTERNAL: 13,
+  UNAVAILABLE: 14,
+  DATA_LOSS: 15,
+  UNAUTHENTICATED: 16
+} as const;

--- a/packages/grpc/src/grpcservice.spec.ts
+++ b/packages/grpc/src/grpcservice.spec.ts
@@ -1,0 +1,1000 @@
+import { suite, test } from "@webda/test";
+import * as assert from "assert";
+import { vi } from "vitest";
+import { existsSync, readFileSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { EventEmitter } from "node:events";
+
+// Tracked operations map for the mock
+const mockOperations: Record<string, any> = {};
+const mockSchemas: Record<string, any> = {};
+const coreEventCallbacks: Record<string, Function> = {};
+let mockCallOperationResult: any = {};
+let mockCallOperationError: any = null;
+/** If set, callOperation will use this as the raw _output string (instead of JSON.stringify(mockCallOperationResult)) */
+let mockCallOperationRawOutput: string | undefined = undefined;
+
+vi.mock("@webda/core", () => {
+  class MockServiceParameters {
+    load(params: any = {}) {
+      Object.assign(this, params);
+      return this;
+    }
+  }
+
+  class MockOperationsTransportParameters extends MockServiceParameters {
+    operations?: string[];
+    load(params: any = {}) {
+      super.load(params);
+      this.operations ??= ["*"];
+      return this;
+    }
+  }
+
+  class MockService {
+    parameters: any;
+    _name: string;
+
+    constructor(name?: string, params?: any) {
+      this._name = name || "test";
+      this.parameters = params || {};
+    }
+
+    log(_level: string, ..._args: any[]) {}
+
+    async resolve() {
+      return this;
+    }
+
+    async init() {
+      return this;
+    }
+
+    async stop() {}
+  }
+
+  class MockOperationsTransport extends MockService {
+    getOperations() {
+      return mockOperations;
+    }
+
+    exposeOperation(_opId: string, _def: any) {}
+  }
+
+  return {
+    Service: MockService,
+    ServiceParameters: MockServiceParameters,
+    OperationsTransport: MockOperationsTransport,
+    OperationsTransportParameters: MockOperationsTransportParameters,
+    OperationDefinition: {},
+    callOperation: async (ctx: any, opId: string) => {
+      if (mockCallOperationError) {
+        throw mockCallOperationError;
+      }
+      if (mockCallOperationRawOutput !== undefined) {
+        ctx._output = mockCallOperationRawOutput;
+      } else {
+        ctx._output = JSON.stringify(mockCallOperationResult);
+      }
+    },
+    OperationContext: class {},
+    SimpleOperationContext: class {
+      _input: Buffer;
+      _output: string;
+
+      async init() {
+        return this;
+      }
+
+      setInput(buf: Buffer) {
+        this._input = buf;
+      }
+
+      getOutput() {
+        return this._output;
+      }
+    },
+    WebContext: class {},
+    useCoreEvents: (eventName: string, callback: Function) => {
+      coreEventCallbacks[eventName] = callback;
+      return () => {
+        delete coreEventCallbacks[eventName];
+      };
+    },
+    useApplication: () => ({
+      getSchemas: () => mockSchemas
+    }),
+    Command: () => () => {}
+  };
+});
+
+vi.mock("@webda/workout", () => ({
+  useLog: () => ({
+    info() {},
+    warn() {},
+    debug() {},
+    error() {}
+  })
+}));
+
+vi.mock("@grpc/proto-loader", () => ({
+  loadSync: vi.fn(function loadSync() {
+    return {};
+  })
+}));
+
+// Dynamic import so mocks are applied first
+const { GrpcService, GrpcServiceParameters } = await import("./grpcservice.js");
+const { GrpcStatus } = await import("./grpc-stream.js");
+
+@suite
+class GrpcServiceParametersTest {
+  @test
+  defaultValues() {
+    const params = new GrpcServiceParameters();
+    params.load({});
+    assert.strictEqual(params.protoFile, ".webda/app.proto");
+    assert.strictEqual(params.packageName, "webda");
+  }
+
+  @test
+  customValues() {
+    const params = new GrpcServiceParameters();
+    params.load({
+      protoFile: "custom.proto",
+      packageName: "myapp"
+    });
+    assert.strictEqual(params.protoFile, "custom.proto");
+    assert.strictEqual(params.packageName, "myapp");
+  }
+
+  @test
+  defaultsNotOverriddenWhenValueProvided() {
+    const params = new GrpcServiceParameters();
+    params.load({ protoFile: "my.proto" });
+    assert.strictEqual(params.protoFile, "my.proto");
+    assert.strictEqual(params.packageName, "webda");
+  }
+}
+
+@suite
+class GrpcServiceExposeOperationTest {
+  @test
+  exposeOperationIsNoOp() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    // Should not throw or do anything
+    service.exposeOperation("Post.Create", { service: "PostService", method: "create" });
+    service.exposeOperation("User.Get", { service: "UserService", method: "get" });
+  }
+}
+
+@suite
+class GrpcServiceCountServicesTest {
+  @test
+  countDistinctPrefixes() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    const operations = {
+      "Post.Create": {},
+      "Post.Get": {},
+      "User.Login": {},
+      "User.Logout": {},
+      "Admin.Stats": {}
+    };
+
+    const count = (service as any).countServices(operations);
+    assert.strictEqual(count, 3);
+  }
+
+  @test
+  operationsWithoutDotUseDefault() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    const operations = {
+      Health: {},
+      Ping: {},
+      "Post.Create": {}
+    };
+
+    // "Health" and "Ping" both map to "Default", plus "Post"
+    const count = (service as any).countServices(operations);
+    assert.strictEqual(count, 2);
+  }
+
+  @test
+  emptyOperations() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const count = (service as any).countServices({});
+    assert.strictEqual(count, 0);
+  }
+}
+
+@suite
+class GrpcServiceErrorMappingTest {
+  @test
+  maps400ToInvalidArgument() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 400, message: "Bad request" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.INVALID_ARGUMENT);
+  }
+
+  @test
+  maps401ToUnauthenticated() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 401, message: "Unauthorized" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.UNAUTHENTICATED);
+  }
+
+  @test
+  maps403ToPermissionDenied() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 403, message: "Forbidden" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.PERMISSION_DENIED);
+  }
+
+  @test
+  maps404ToNotFound() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 404, message: "Not found" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.NOT_FOUND);
+  }
+
+  @test
+  maps409ToAlreadyExists() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 409, message: "Conflict" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.ALREADY_EXISTS);
+  }
+
+  @test
+  maps429ToResourceExhausted() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 429, message: "Too many requests" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.RESOURCE_EXHAUSTED);
+  }
+
+  @test
+  mapsUnknownCodeToInternal() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = { getResponseCode: () => 500, message: "Server error" };
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.INTERNAL);
+  }
+
+  @test
+  mapsErrorWithoutGetResponseCodeToInternal() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    const err = new Error("plain error");
+    assert.strictEqual((service as any).errorToGrpcStatus(err), GrpcStatus.INTERNAL);
+  }
+
+  @test
+  mapsNullErrorToInternal() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+    assert.strictEqual((service as any).errorToGrpcStatus(null), GrpcStatus.INTERNAL);
+    assert.strictEqual((service as any).errorToGrpcStatus(undefined), GrpcStatus.INTERNAL);
+  }
+}
+
+@suite
+class GrpcServiceGenerateProtoTest {
+  private tmpDir: string;
+
+  beforeEach() {
+    this.tmpDir = join(tmpdir(), `grpc-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(this.tmpDir, { recursive: true });
+
+    // Clear mockOperations
+    for (const key of Object.keys(mockOperations)) {
+      delete mockOperations[key];
+    }
+    for (const key of Object.keys(mockSchemas)) {
+      delete mockSchemas[key];
+    }
+  }
+
+  afterEach() {
+    try {
+      rmSync(this.tmpDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+
+  @test
+  async writesProtoFile() {
+    mockOperations["Post.Create"] = {
+      service: "PostService",
+      method: "create"
+    };
+    mockOperations["Post.Get"] = {
+      service: "PostService",
+      method: "get"
+    };
+
+    const outPath = join(this.tmpDir, "output", "app.proto");
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: outPath }));
+
+    await service.generateProto();
+
+    assert.ok(existsSync(outPath), "Proto file should be written");
+    const content = readFileSync(outPath, "utf-8");
+    assert.ok(content.includes('syntax = "proto3"'), "Should contain proto3 syntax");
+    assert.ok(content.includes("service PostService {"), "Should contain PostService");
+    assert.ok(content.includes("rpc Create"), "Should contain Create rpc");
+    assert.ok(content.includes("rpc Get"), "Should contain Get rpc");
+  }
+
+  @test
+  async writesProtoFileToCustomOutputPath() {
+    mockOperations["Health"] = {
+      service: "HealthService",
+      method: "check"
+    };
+
+    const customPath = join(this.tmpDir, "custom.proto");
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    await service.generateProto(customPath);
+
+    assert.ok(existsSync(customPath), "Proto file should be written to custom path");
+    const content = readFileSync(customPath, "utf-8");
+    assert.ok(content.includes("service DefaultService {"), "Should contain DefaultService");
+  }
+
+  @test
+  async usesCustomPackageName() {
+    mockOperations["Test.Ping"] = {};
+
+    const outPath = join(this.tmpDir, "test.proto");
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: outPath, packageName: "myapp" }));
+
+    await service.generateProto();
+
+    const content = readFileSync(outPath, "utf-8");
+    assert.ok(content.includes("package myapp;"), "Should use custom package name");
+  }
+
+  @test
+  async createsDirectoryIfNotExists() {
+    mockOperations["Test.Op"] = {};
+
+    const deepPath = join(this.tmpDir, "deep", "nested", "dir", "app.proto");
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: deepPath }));
+
+    await service.generateProto();
+
+    assert.ok(existsSync(deepPath), "Should create nested directories and write file");
+  }
+
+  @test
+  async emptyOperationsStillProducesValidProto() {
+    const outPath = join(this.tmpDir, "empty.proto");
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: outPath }));
+
+    await service.generateProto();
+
+    assert.ok(existsSync(outPath), "Proto file should be written even with no operations");
+    const content = readFileSync(outPath, "utf-8");
+    assert.ok(content.includes('syntax = "proto3"'));
+  }
+}
+
+/**
+ * Create a gRPC frame from a JSON message
+ */
+function createGrpcFrame(data: any): Buffer {
+  const payload = Buffer.from(JSON.stringify(data));
+  const frame = Buffer.alloc(5 + payload.length);
+  frame.writeUInt8(0, 0);
+  frame.writeUInt32BE(payload.length, 1);
+  payload.copy(frame, 5);
+  return frame;
+}
+
+/**
+ * Create a mock request EventEmitter that simulates an HTTP request with gRPC data
+ */
+function createMockReq(url: string, frameData?: any): EventEmitter & { url: string; headers: Record<string, string> } {
+  const req = new EventEmitter() as any;
+  req.url = url;
+  req.headers = { "content-type": "application/grpc" };
+
+  if (frameData !== undefined) {
+    // Schedule data emission on next tick so handlers can be registered
+    process.nextTick(() => {
+      const frame = createGrpcFrame(frameData);
+      req.emit("data", frame);
+      // For client/bidi streaming, also emit end
+      req.emit("end");
+    });
+  }
+
+  return req;
+}
+
+/**
+ * Create a mock response that captures what was written
+ */
+function createMockRes(): {
+  res: any;
+  written: Buffer[];
+  trailers: Record<string, string> | null;
+  ended: boolean;
+  headStatus: number;
+  headHeaders: Record<string, string>;
+  headers: Record<string, string>;
+} {
+  const state = {
+    written: [] as Buffer[],
+    trailers: null as Record<string, string> | null,
+    ended: false,
+    headStatus: 0,
+    headHeaders: {} as Record<string, string>,
+    headers: {} as Record<string, string>,
+    res: null as any
+  };
+
+  state.res = {
+    setHeader(key: string, value: string) {
+      state.headers[key] = value;
+    },
+    writeHead(status: number, headers: any) {
+      state.headStatus = status;
+      state.headHeaders = headers || {};
+    },
+    write(data: Buffer) {
+      state.written.push(Buffer.from(data));
+    },
+    addTrailers(t: Record<string, string>) {
+      state.trailers = t;
+    },
+    end() {
+      state.ended = true;
+    }
+  };
+
+  return state;
+}
+
+/**
+ * Create a JSON-based method definition mock
+ */
+function createJsonMethodDef() {
+  return {
+    path: "/webda.TestService/TestMethod",
+    requestSerialize: (msg: any) => Buffer.from(JSON.stringify(msg)),
+    requestDeserialize: (buf: Buffer) => JSON.parse(buf.toString()),
+    responseSerialize: (msg: any) => Buffer.from(JSON.stringify(msg)),
+    responseDeserialize: (buf: Buffer) => JSON.parse(buf.toString()),
+    requestStream: false,
+    responseStream: false
+  };
+}
+
+/**
+ * Set up a service with a mapped rpc method
+ */
+function setupServiceWithRpc(opId: string, opDef: any = {}): InstanceType<typeof GrpcService> {
+  const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+  const methodDef = createJsonMethodDef();
+  const grpcPath = `/webda.TestService/${opId.split(".").pop()}`;
+
+  // Manually set up the rpcToOperation and rpcMethods maps
+  (service as any).rpcToOperation.set(grpcPath, opId);
+  (service as any).rpcMethods.set(grpcPath, methodDef);
+
+  // Set up the mock operation
+  mockOperations[opId] = opDef;
+
+  return service;
+}
+
+@suite
+class GrpcServiceHandleGrpcRequestTest {
+  beforeEach() {
+    // Clear operations
+    for (const key of Object.keys(mockOperations)) {
+      delete mockOperations[key];
+    }
+    mockCallOperationResult = {};
+    mockCallOperationError = null;
+    mockCallOperationRawOutput = undefined;
+  }
+
+  @test
+  async unimplementedMethodReturns12() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    let writtenHeaders: any = {};
+    let ended = false;
+    const req = { url: "/webda.UnknownService/UnknownMethod" };
+    const res = {
+      writeHead(status: number, headers: any) {
+        writtenHeaders = headers;
+      },
+      end() {
+        ended = true;
+      }
+    };
+
+    await service.handleGrpcRequest(req as any, res as any);
+
+    assert.strictEqual(writtenHeaders["grpc-status"], String(GrpcStatus.UNIMPLEMENTED));
+    const decodedMessage = decodeURIComponent(writtenHeaders["grpc-message"]);
+    assert.ok(decodedMessage.includes("Method not found"), `Expected 'Method not found' in: ${decodedMessage}`);
+    assert.ok(ended);
+  }
+
+  @test
+  async unaryRequestReturnsResponse() {
+    const service = setupServiceWithRpc("Test.DoSomething", {});
+    mockCallOperationResult = { success: true, id: "123" };
+
+    const grpcPath = "/webda.TestService/DoSomething";
+    const req = createMockReq(grpcPath, { input: "hello" });
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    // Should have written a response frame
+    assert.strictEqual(mock.written.length, 1);
+    const payload = mock.written[0].subarray(5);
+    const response = JSON.parse(payload.toString());
+    assert.deepStrictEqual(response, { success: true, id: "123" });
+
+    // Should have ended with status 0
+    assert.ok(mock.trailers !== null);
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+    assert.ok(mock.ended);
+  }
+
+  @test
+  async unaryRequestHandlesOperationError() {
+    const service = setupServiceWithRpc("Test.FailOp", {});
+    mockCallOperationError = {
+      getResponseCode: () => 404,
+      message: "Resource not found"
+    };
+
+    const grpcPath = "/webda.TestService/FailOp";
+    const req = createMockReq(grpcPath, { id: "missing" });
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    // Should have ended with error status
+    assert.ok(mock.trailers !== null);
+    assert.strictEqual(mock.trailers!["grpc-status"], String(GrpcStatus.NOT_FOUND));
+    assert.ok(mock.ended);
+  }
+
+  @test
+  async serverStreamingReturnsMultipleMessages() {
+    const service = setupServiceWithRpc("Test.StreamItems", {
+      grpc: { streaming: "server" }
+    });
+    mockCallOperationRawOutput = '{"id":1}\n{"id":2}\n{"id":3}';
+
+    const grpcPath = "/webda.TestService/StreamItems";
+    const req = createMockReq(grpcPath, { query: "all" });
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    // Should have written 3 response frames (one per NDJSON line)
+    assert.strictEqual(mock.written.length, 3, `Expected 3 frames, got ${mock.written.length}`);
+
+    const msg1 = JSON.parse(mock.written[0].subarray(5).toString());
+    const msg2 = JSON.parse(mock.written[1].subarray(5).toString());
+    const msg3 = JSON.parse(mock.written[2].subarray(5).toString());
+    assert.deepStrictEqual(msg1, { id: 1 });
+    assert.deepStrictEqual(msg2, { id: 2 });
+    assert.deepStrictEqual(msg3, { id: 3 });
+
+    // Should end with OK
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async serverStreamingHandlesNonJsonLines() {
+    const service = setupServiceWithRpc("Test.StreamRaw", {
+      grpc: { streaming: "server" }
+    });
+    mockCallOperationRawOutput = 'not-json-line\n{"valid":true}';
+
+    const grpcPath = "/webda.TestService/StreamRaw";
+    const req = createMockReq(grpcPath, {});
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    // First line is not valid JSON, should be wrapped in { data: ... }
+    assert.strictEqual(mock.written.length, 2);
+    const msg1 = JSON.parse(mock.written[0].subarray(5).toString());
+    assert.deepStrictEqual(msg1, { data: "not-json-line" });
+    const msg2 = JSON.parse(mock.written[1].subarray(5).toString());
+    assert.deepStrictEqual(msg2, { valid: true });
+  }
+
+  @test
+  async serverStreamingHandlesNoOutput() {
+    const service = setupServiceWithRpc("Test.StreamEmpty", {
+      grpc: { streaming: "server" }
+    });
+    // Set rawOutput to empty string to simulate no output
+    mockCallOperationRawOutput = "";
+
+    const grpcPath = "/webda.TestService/StreamEmpty";
+    const req = createMockReq(grpcPath, {});
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    // No data frames should be written (empty string filtered by split+filter)
+    assert.strictEqual(mock.written.length, 0);
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async serverStreamingHandlesOperationError() {
+    const service = setupServiceWithRpc("Test.StreamFail", {
+      grpc: { streaming: "server" }
+    });
+    const err: any = new Error("Stream failed");
+    err.getResponseCode = () => 400;
+    mockCallOperationError = err;
+
+    const grpcPath = "/webda.TestService/StreamFail";
+    const req = createMockReq(grpcPath, {});
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    assert.strictEqual(mock.trailers!["grpc-status"], String(GrpcStatus.INVALID_ARGUMENT));
+  }
+
+  @test
+  async clientStreamingCollectsMessagesAndResponds() {
+    const service = setupServiceWithRpc("Test.Upload", {
+      grpc: { streaming: "client" }
+    });
+
+    const grpcPath = "/webda.TestService/Upload";
+
+    // Create mock req that will emit multiple messages then end
+    const req = new EventEmitter() as any;
+    req.url = grpcPath;
+    req.headers = { "content-type": "application/grpc" };
+
+    const mock = createMockRes();
+
+    mockCallOperationResult = { count: 2, status: "received" };
+
+    const promise = service.handleGrpcRequest(req as any, mock.res);
+
+    // Emit two messages
+    process.nextTick(() => {
+      req.emit("data", createGrpcFrame({ item: "a" }));
+      req.emit("data", createGrpcFrame({ item: "b" }));
+      // End the stream
+      req.emit("end");
+    });
+
+    await promise;
+
+    // Should respond with a unary response (sendUnary)
+    assert.strictEqual(mock.written.length, 1);
+    const response = JSON.parse(mock.written[0].subarray(5).toString());
+    assert.deepStrictEqual(response, { count: 2, status: "received" });
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async bidiStreamingCollectsAndSendsResponse() {
+    const service = setupServiceWithRpc("Test.Chat", {
+      grpc: { streaming: "bidi" }
+    });
+
+    const grpcPath = "/webda.TestService/Chat";
+    const req = new EventEmitter() as any;
+    req.url = grpcPath;
+    req.headers = { "content-type": "application/grpc" };
+
+    const mock = createMockRes();
+
+    mockCallOperationResult = { reply: "ack" };
+
+    const promise = service.handleGrpcRequest(req as any, mock.res);
+
+    process.nextTick(() => {
+      req.emit("data", createGrpcFrame({ msg: "hello" }));
+      req.emit("end");
+    });
+
+    await promise;
+
+    // Bidi uses stream.send (not sendUnary), so no trailers with end
+    // The current implementation sends once then resolves
+    assert.strictEqual(mock.written.length, 1);
+    const response = JSON.parse(mock.written[0].subarray(5).toString());
+    assert.deepStrictEqual(response, { reply: "ack" });
+  }
+
+  @test
+  async clientStreamingHandlesOperationError() {
+    const service = setupServiceWithRpc("Test.UploadFail", {
+      grpc: { streaming: "client" }
+    });
+    const err: any = new Error("Upload failed");
+    err.getResponseCode = () => 401;
+    mockCallOperationError = err;
+
+    const grpcPath = "/webda.TestService/UploadFail";
+    const req = new EventEmitter() as any;
+    req.url = grpcPath;
+    req.headers = { "content-type": "application/grpc" };
+
+    const mock = createMockRes();
+
+    const promise = service.handleGrpcRequest(req as any, mock.res);
+
+    process.nextTick(() => {
+      req.emit("data", createGrpcFrame({ item: "x" }));
+      req.emit("end");
+    });
+
+    await promise;
+
+    assert.strictEqual(mock.trailers!["grpc-status"], String(GrpcStatus.UNAUTHENTICATED));
+  }
+
+  @test
+  async clientStreamingHandlesCancellation() {
+    const service = setupServiceWithRpc("Test.CancelUpload", {
+      grpc: { streaming: "client" }
+    });
+
+    const grpcPath = "/webda.TestService/CancelUpload";
+    const req = new EventEmitter() as any;
+    req.url = grpcPath;
+    req.headers = { "content-type": "application/grpc" };
+
+    const mock = createMockRes();
+
+    const promise = service.handleGrpcRequest(req as any, mock.res);
+
+    // Emit close (cancellation) instead of end
+    process.nextTick(() => {
+      req.emit("close");
+    });
+
+    await promise;
+
+    // Should resolve without writing data
+    assert.strictEqual(mock.written.length, 0);
+  }
+
+  @test
+  async unaryWithNoGrpcFieldUsesNoneStreaming() {
+    // Operation without grpc field should default to unary
+    const service = setupServiceWithRpc("Test.Simple", {
+      // no grpc field at all
+    });
+
+    mockCallOperationResult = { ok: true };
+
+    const grpcPath = "/webda.TestService/Simple";
+    const req = createMockReq(grpcPath, { query: "test" });
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    assert.strictEqual(mock.written.length, 1);
+    assert.strictEqual(mock.trailers!["grpc-status"], "0");
+  }
+
+  @test
+  async unaryWithNullOutputReturnsEmptyObject() {
+    const service = setupServiceWithRpc("Test.NoOutput", {});
+    mockCallOperationRawOutput = "";
+
+    const grpcPath = "/webda.TestService/NoOutput";
+    const req = createMockReq(grpcPath, {});
+    const mock = createMockRes();
+
+    await service.handleGrpcRequest(req as any, mock.res);
+
+    assert.strictEqual(mock.written.length, 1);
+    const response = JSON.parse(mock.written[0].subarray(5).toString());
+    assert.deepStrictEqual(response, {});
+  }
+}
+
+@suite
+class GrpcServiceBuildRpcMapTest {
+  beforeEach() {
+    for (const key of Object.keys(mockOperations)) {
+      delete mockOperations[key];
+    }
+  }
+
+  @test
+  async buildRpcMapWithMatchingOperations() {
+    mockOperations["Post.Create"] = { service: "PostService", method: "create" };
+    mockOperations["Post.Get"] = { service: "PostService", method: "get" };
+
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ packageName: "webda" }));
+
+    // Set up definitions that match the operations
+    (service as any).definitions = {
+      "webda.PostService.Create": {
+        path: "/webda.PostService/Create",
+        requestSerialize: () => Buffer.alloc(0),
+        requestDeserialize: () => ({}),
+        responseSerialize: () => Buffer.alloc(0),
+        responseDeserialize: () => ({})
+      },
+      "webda.PostService.Get": {
+        path: "/webda.PostService/Get",
+        requestSerialize: () => Buffer.alloc(0),
+        requestDeserialize: () => ({}),
+        responseSerialize: () => Buffer.alloc(0),
+        responseDeserialize: () => ({})
+      }
+    };
+
+    (service as any).buildRpcMap();
+
+    assert.strictEqual((service as any).rpcToOperation.size, 2);
+    assert.strictEqual((service as any).rpcToOperation.get("/webda.PostService/Create"), "Post.Create");
+    assert.strictEqual((service as any).rpcToOperation.get("/webda.PostService/Get"), "Post.Get");
+  }
+
+  @test
+  async buildRpcMapSkipsNonObjectDefs() {
+    mockOperations["Post.Create"] = {};
+
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    (service as any).definitions = {
+      someString: "not an object",
+      someNull: null,
+      someNumber: 42
+    };
+
+    (service as any).buildRpcMap();
+
+    assert.strictEqual((service as any).rpcToOperation.size, 0);
+  }
+
+  @test
+  async buildRpcMapSkipsDefsWithoutPath() {
+    mockOperations["Post.Create"] = {};
+
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    (service as any).definitions = {
+      someObj: { requestSerialize: () => Buffer.alloc(0) } // no path
+    };
+
+    (service as any).buildRpcMap();
+
+    assert.strictEqual((service as any).rpcToOperation.size, 0);
+  }
+
+  @test
+  async buildRpcMapSkipsUnmatchedOperations() {
+    // Operations don't match the gRPC path names
+    mockOperations["User.Login"] = {};
+
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    (service as any).definitions = {
+      "webda.PostService.Create": {
+        path: "/webda.PostService/Create"
+      }
+    };
+
+    (service as any).buildRpcMap();
+
+    // Post.Create is not in mockOperations, so it should not be mapped
+    assert.strictEqual((service as any).rpcToOperation.size, 0);
+  }
+
+  @test
+  async buildRpcMapHandlesUndefinedDefinitions() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    // definitions is not set
+    (service as any).definitions = undefined;
+
+    // Should not throw
+    (service as any).buildRpcMap();
+
+    assert.strictEqual((service as any).rpcToOperation.size, 0);
+  }
+
+  @test
+  async buildRpcMapHandlesInvalidPathFormat() {
+    mockOperations["Post.Create"] = {};
+
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({}));
+
+    (service as any).definitions = {
+      invalid: {
+        path: "/single-segment" // only one segment after split+filter
+      }
+    };
+
+    (service as any).buildRpcMap();
+
+    assert.strictEqual((service as any).rpcToOperation.size, 0);
+  }
+}
+
+@suite
+class GrpcServiceInitTest {
+  @test
+  async initWithoutProtoFileLogsWarning() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: "/nonexistent/path/app.proto" }));
+
+    // Should not throw
+    await service.init();
+  }
+
+  @test
+  async initWithExistingProtoFileLoadsDefinitions() {
+    const tmpDir = join(tmpdir(), `grpc-init-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    const protoPath = join(tmpDir, "app.proto");
+    writeFileSync(protoPath, 'syntax = "proto3"; package webda;');
+
+    try {
+      const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: protoPath }));
+      // Should not throw — the mock proto-loader returns an empty object
+      await service.init();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  @test
+  async initRegistersHttpEventHook() {
+    const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: "/nonexistent/file.proto" }));
+
+    await service.init();
+
+    // The init should have registered Webda.Init.Http event callback
+    assert.ok(coreEventCallbacks["Webda.Init.Http"], "Should register Webda.Init.Http event");
+
+    // Call the callback with a mock server
+    coreEventCallbacks["Webda.Init.Http"]({ server: { on: () => {} } });
+
+    // Also test with server that doesn't have 'on'
+    coreEventCallbacks["Webda.Init.Http"]({ server: null });
+  }
+
+  @test
+  async initHandlesProtoLoadError() {
+    const tmpDir = join(tmpdir(), `grpc-init-err-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+    const protoPath = join(tmpDir, "bad.proto");
+    writeFileSync(protoPath, "invalid proto content");
+
+    // Make the mock throw on loadSync
+    const protoLoader = await import("@grpc/proto-loader");
+    vi.mocked(protoLoader.loadSync).mockImplementationOnce(() => {
+      throw new Error("Parse error");
+    });
+
+    try {
+      const service = new GrpcService("testGrpc", new GrpcServiceParameters().load({ protoFile: protoPath }));
+      // Should not throw — error is caught and logged
+      await service.init();
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/grpc/src/grpcservice.ts
+++ b/packages/grpc/src/grpcservice.ts
@@ -4,6 +4,7 @@ import {
   OperationDefinition,
   callOperation,
   OperationContext,
+  SimpleOperationContext,
   WebContext,
   useCoreEvents,
   useApplication,
@@ -129,7 +130,7 @@ export class GrpcService<
         });
         this.buildRpcMap();
         this.log("INFO", `Loaded gRPC definitions from ${this.parameters.protoFile}`);
-      } catch (err) {
+      } catch (err: any) {
         this.log("WARN", `Failed to load proto file: ${err.message}`);
       }
     } else {
@@ -158,7 +159,7 @@ export class GrpcService<
     for (const [servicePath, def] of Object.entries(this.definitions)) {
       // servicePath looks like "webda.PostService" or just the method def
       if (typeof def !== "object" || !def) continue;
-      const methodDef = def as protoLoader.MethodDefinition<any, any>;
+      const methodDef = def as unknown as protoLoader.MethodDefinition<any, any>;
       if (methodDef.path) {
         // This is a method definition — path is like "/webda.PostService/Create"
         const grpcPath = methodDef.path;
@@ -204,7 +205,8 @@ export class GrpcService<
 
     const stream = new GrpcStream(req, res, methodDef);
     const operation = this.getOperations()[opId];
-    const streaming = operation?.grpc?.streaming || "none";
+    const grpc = operation?.grpc;
+    const streaming = (typeof grpc === "object" && grpc ? grpc.streaming : undefined) || "none";
 
     try {
       if (streaming === "bidi" || streaming === "client") {
@@ -238,7 +240,7 @@ export class GrpcService<
     return new Promise<void>((resolve, reject) => {
       stream.onMessage(async message => {
         try {
-          const ctx = new OperationContext();
+          const ctx = new SimpleOperationContext();
           await ctx.init();
           ctx.setInput(Buffer.from(JSON.stringify(message)));
           await callOperation(ctx, opId);
@@ -246,7 +248,7 @@ export class GrpcService<
           const response = output ? JSON.parse(output) : {};
           stream.sendUnary(response);
           resolve();
-        } catch (err) {
+        } catch (err: any) {
           const status = this.errorToGrpcStatus(err);
           stream.sendError(status, err.message);
           resolve(); // Don't reject — error was sent via gRPC status
@@ -271,7 +273,7 @@ export class GrpcService<
     return new Promise<void>((resolve, reject) => {
       stream.onMessage(async message => {
         try {
-          const ctx = new OperationContext();
+          const ctx = new SimpleOperationContext();
           await ctx.init();
           ctx.setInput(Buffer.from(JSON.stringify(message)));
           await callOperation(ctx, opId);
@@ -291,7 +293,7 @@ export class GrpcService<
           }
           stream.end(GrpcStatus.OK);
           resolve();
-        } catch (err) {
+        } catch (err: any) {
           const status = this.errorToGrpcStatus(err);
           stream.sendError(status, err.message);
           resolve();
@@ -322,7 +324,7 @@ export class GrpcService<
       stream.onEnd(async () => {
         try {
           // For client streaming: process all collected messages
-          const ctx = new OperationContext();
+          const ctx = new SimpleOperationContext();
           await ctx.init();
           ctx.setInput(Buffer.from(JSON.stringify(messages)));
           await callOperation(ctx, opId);
@@ -337,7 +339,7 @@ export class GrpcService<
             stream.sendUnary(response);
           }
           resolve();
-        } catch (err) {
+        } catch (err: any) {
           const status = this.errorToGrpcStatus(err);
           stream.sendError(status, err.message);
           resolve();

--- a/packages/grpc/src/grpcservice.ts
+++ b/packages/grpc/src/grpcservice.ts
@@ -1,0 +1,387 @@
+import {
+  OperationsTransport,
+  OperationsTransportParameters,
+  OperationDefinition,
+  callOperation,
+  OperationContext,
+  WebContext,
+  useCoreEvents,
+  useApplication,
+  Command,
+  ServiceParameters
+} from "@webda/core";
+import { useLog } from "@webda/workout";
+import * as protoLoader from "@grpc/proto-loader";
+import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { GrpcStream, GrpcStatus } from "./grpc-stream.js";
+import { generateProto } from "./proto-generator.js";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+/**
+ * Parameters for the gRPC service
+ */
+export class GrpcServiceParameters extends OperationsTransportParameters {
+  /**
+   * Path to the generated .proto file
+   * @default ".webda/app.proto"
+   */
+  protoFile?: string;
+
+  /**
+   * Protobuf package name
+   * @default "webda"
+   */
+  packageName?: string;
+
+  /**
+   * Load and apply default parameter values.
+   * @param params - raw configuration object to load into this parameters instance
+   * @returns this instance with defaults applied
+   */
+  load(params: any = {}): this {
+    super.load(params);
+    this.protoFile ??= ".webda/app.proto";
+    this.packageName ??= "webda";
+    return this;
+  }
+}
+
+/**
+ * gRPC transport service.
+ *
+ * Exposes Webda operations as gRPC services over HTTP/2.
+ * Hooks into the HttpServer via the `Webda.Init.Http` event to intercept
+ * requests with `content-type: application/grpc`.
+ *
+ * Use the `generate-proto` command to create the .proto file from operations.
+ *
+ * @WebdaModda
+ */
+export class GrpcService<
+  T extends GrpcServiceParameters = GrpcServiceParameters
+> extends OperationsTransport<T> {
+  /** Loaded protobuf definitions */
+  private definitions: protoLoader.PackageDefinition;
+  /** Map of gRPC path → operation ID */
+  private rpcToOperation: Map<string, string> = new Map();
+  /** Map of gRPC path → method definition */
+  private rpcMethods: Map<string, protoLoader.MethodDefinition<any, any>> = new Map();
+
+  /**
+   * Generate a .proto file from the current operation registry.
+   *
+   * @param output - output file path (defaults to parameters.protoFile)
+   * @returns a promise that resolves when the proto file has been written to disk
+   */
+  @Command("generate-proto", { description: "Generate protobuf definition from operations", requires: ["rest-domain"] })
+  async generateProto(
+    /** @alias o @description Output file path */
+    output?: string
+  ): Promise<void> {
+    const outPath = output || this.parameters.protoFile;
+    const operations = this.getOperations();
+    const schemas = useApplication().getSchemas?.() || {};
+
+    const proto = generateProto(operations, schemas, this.parameters.packageName);
+
+    // Ensure directory exists
+    const dir = dirname(outPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+
+    writeFileSync(outPath, proto, "utf-8");
+    this.log("INFO", `Generated proto file: ${outPath}`);
+    this.log("INFO", `  ${Object.keys(operations).length} operations → ${this.countServices(operations)} services`);
+  }
+
+  /**
+   * Count unique service prefixes in operations
+   * @param operations - map of operation IDs to their definitions
+   * @returns the number of distinct gRPC service groups derived from operation prefixes
+   */
+  private countServices(operations: Record<string, any>): number {
+    const prefixes = new Set<string>();
+    for (const opId of Object.keys(operations)) {
+      const dot = opId.indexOf(".");
+      prefixes.add(dot > 0 ? opId.substring(0, dot) : "Default");
+    }
+    return prefixes.size;
+  }
+
+  /**
+   * Initialize the gRPC transport: load proto, build RPC map, hook into HTTP/2.
+   * @returns a promise resolving to this service instance once initialization is complete
+   */
+  async init(): Promise<this> {
+    await super.init();
+
+    // Load proto file if it exists
+    if (existsSync(this.parameters.protoFile)) {
+      try {
+        this.definitions = protoLoader.loadSync(this.parameters.protoFile, {
+          keepCase: true,
+          longs: String,
+          enums: String,
+          defaults: true,
+          oneofs: true
+        });
+        this.buildRpcMap();
+        this.log("INFO", `Loaded gRPC definitions from ${this.parameters.protoFile}`);
+      } catch (err) {
+        this.log("WARN", `Failed to load proto file: ${err.message}`);
+      }
+    } else {
+      this.log("WARN", `Proto file not found: ${this.parameters.protoFile}. Run 'webda generate-proto' first.`);
+    }
+
+    // Hook into HttpServer to intercept gRPC requests
+    useCoreEvents("Webda.Init.Http" as any, ({ server }: any) => {
+      if (server?.on) {
+        this.log("DEBUG", "Registered gRPC request interceptor on HTTP server");
+      }
+    });
+
+    return this;
+  }
+
+  /**
+   * Build the mapping from gRPC path → operation ID using the loaded proto definitions.
+   */
+  private buildRpcMap(): void {
+    if (!this.definitions) return;
+
+    const operations = this.getOperations();
+    const pkg = this.parameters.packageName;
+
+    for (const [servicePath, def] of Object.entries(this.definitions)) {
+      // servicePath looks like "webda.PostService" or just the method def
+      if (typeof def !== "object" || !def) continue;
+      const methodDef = def as protoLoader.MethodDefinition<any, any>;
+      if (methodDef.path) {
+        // This is a method definition — path is like "/webda.PostService/Create"
+        const grpcPath = methodDef.path;
+        // Extract service and method from path: /package.ServiceName/MethodName
+        const parts = grpcPath.split("/").filter(Boolean);
+        if (parts.length === 2) {
+          const [fullService, method] = parts;
+          const serviceName = fullService.replace(`${pkg}.`, "").replace("Service", "");
+          const opId = `${serviceName}.${method}`;
+          if (operations[opId]) {
+            this.rpcToOperation.set(grpcPath, opId);
+            this.rpcMethods.set(grpcPath, methodDef);
+          }
+        }
+      }
+    }
+    this.log("DEBUG", `Mapped ${this.rpcToOperation.size} gRPC methods to operations`);
+  }
+
+  /**
+   * Handle an incoming gRPC request.
+   *
+   * Called by the HttpServer when content-type is application/grpc.
+   *
+   * @param req - HTTP/2 request carrying the gRPC method path and framed message body
+   * @param res - HTTP/2 response used to write gRPC frames and trailers
+   * @returns a promise that resolves when the response has been fully sent
+   */
+  async handleGrpcRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const grpcPath = req.url;
+    const opId = this.rpcToOperation.get(grpcPath);
+    const methodDef = this.rpcMethods.get(grpcPath);
+
+    if (!opId || !methodDef) {
+      res.writeHead(200, {
+        "content-type": "application/grpc",
+        "grpc-status": String(GrpcStatus.UNIMPLEMENTED),
+        "grpc-message": encodeURIComponent(`Method not found: ${grpcPath}`)
+      });
+      res.end();
+      return;
+    }
+
+    const stream = new GrpcStream(req, res, methodDef);
+    const operation = this.getOperations()[opId];
+    const streaming = operation?.grpc?.streaming || "none";
+
+    try {
+      if (streaming === "bidi" || streaming === "client") {
+        // Client/bidi streaming — collect messages and process
+        await this.handleStreamingRequest(stream, opId, streaming);
+      } else if (streaming === "server") {
+        // Server streaming — single request, stream responses
+        await this.handleServerStreaming(stream, opId, methodDef);
+      } else {
+        // Unary — single request, single response
+        await this.handleUnary(stream, opId, methodDef);
+      }
+    } catch (err) {
+      const status = this.errorToGrpcStatus(err);
+      stream.sendError(status, err.message || "Internal error");
+    }
+  }
+
+  /**
+   * Handle a unary gRPC call (single request → single response).
+   * @param stream - the active GrpcStream for this request
+   * @param opId - the Webda operation ID to invoke
+   * @param methodDef - the protobuf method definition with serializer functions
+   * @returns a promise that resolves when the unary response has been sent
+   */
+  private handleUnary(
+    stream: GrpcStream,
+    opId: string,
+    methodDef: protoLoader.MethodDefinition<any, any>
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      stream.onMessage(async message => {
+        try {
+          const ctx = new OperationContext();
+          await ctx.init();
+          ctx.setInput(Buffer.from(JSON.stringify(message)));
+          await callOperation(ctx, opId);
+          const output = ctx.getOutput();
+          const response = output ? JSON.parse(output) : {};
+          stream.sendUnary(response);
+          resolve();
+        } catch (err) {
+          const status = this.errorToGrpcStatus(err);
+          stream.sendError(status, err.message);
+          resolve(); // Don't reject — error was sent via gRPC status
+        }
+      });
+    });
+  }
+
+  /**
+   * Handle server streaming (single request → stream of responses).
+   * Maps to AsyncGenerator operations.
+   * @param stream - the active GrpcStream for this request
+   * @param opId - the Webda operation ID to invoke
+   * @param methodDef - the protobuf method definition with serializer functions
+   * @returns a promise that resolves when all response frames have been sent
+   */
+  private handleServerStreaming(
+    stream: GrpcStream,
+    opId: string,
+    methodDef: protoLoader.MethodDefinition<any, any>
+  ): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      stream.onMessage(async message => {
+        try {
+          const ctx = new OperationContext();
+          await ctx.init();
+          ctx.setInput(Buffer.from(JSON.stringify(message)));
+          await callOperation(ctx, opId);
+          // callOperation writes chunks to ctx for AsyncGenerators
+          // For now, send the full output as a single response
+          const output = ctx.getOutput();
+          if (output) {
+            // Try to parse as NDJSON (multiple JSON objects)
+            const lines = output.split("\n").filter(Boolean);
+            for (const line of lines) {
+              try {
+                stream.send(JSON.parse(line));
+              } catch {
+                stream.send({ data: line });
+              }
+            }
+          }
+          stream.end(GrpcStatus.OK);
+          resolve();
+        } catch (err) {
+          const status = this.errorToGrpcStatus(err);
+          stream.sendError(status, err.message);
+          resolve();
+        }
+      });
+    });
+  }
+
+  /**
+   * Handle client or bidirectional streaming.
+   * @param stream - the active GrpcStream for this request
+   * @param opId - the Webda operation ID to invoke
+   * @param streaming - streaming mode, either "client" or "bidi"
+   * @returns a promise that resolves when the operation completes and the response is sent
+   */
+  private handleStreamingRequest(
+    stream: GrpcStream,
+    opId: string,
+    streaming: string
+  ): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const messages: any[] = [];
+
+      stream.onMessage(message => {
+        messages.push(message);
+      });
+
+      stream.onEnd(async () => {
+        try {
+          // For client streaming: process all collected messages
+          const ctx = new OperationContext();
+          await ctx.init();
+          ctx.setInput(Buffer.from(JSON.stringify(messages)));
+          await callOperation(ctx, opId);
+          const output = ctx.getOutput();
+          const response = output ? JSON.parse(output) : {};
+
+          if (streaming === "bidi") {
+            // Bidi: send response for each input message
+            stream.send(response);
+          } else {
+            // Client streaming: single response
+            stream.sendUnary(response);
+          }
+          resolve();
+        } catch (err) {
+          const status = this.errorToGrpcStatus(err);
+          stream.sendError(status, err.message);
+          resolve();
+        }
+      });
+
+      stream.onCancel(() => {
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Map a Webda error to a gRPC status code.
+   * @param err - the error thrown by a Webda operation, expected to have a getResponseCode method
+   * @returns the corresponding gRPC status code integer
+   */
+  private errorToGrpcStatus(err: any): number {
+    const code = err?.getResponseCode?.();
+    switch (code) {
+      case 400:
+        return GrpcStatus.INVALID_ARGUMENT;
+      case 401:
+        return GrpcStatus.UNAUTHENTICATED;
+      case 403:
+        return GrpcStatus.PERMISSION_DENIED;
+      case 404:
+        return GrpcStatus.NOT_FOUND;
+      case 409:
+        return GrpcStatus.ALREADY_EXISTS;
+      case 429:
+        return GrpcStatus.RESOURCE_EXHAUSTED;
+      default:
+        return GrpcStatus.INTERNAL;
+    }
+  }
+
+  /**
+   * No-op — gRPC operations are exposed via the proto definition, not individual routes.
+   * @param _operationId - the operation ID (unused; routing is handled by the proto definition)
+   * @param _definition - the operation definition (unused)
+   * @returns void
+   */
+  exposeOperation(_operationId: string, _definition: OperationDefinition): void {
+    // gRPC doesn't register routes individually — handled by proto definition
+  }
+}

--- a/packages/grpc/src/index.ts
+++ b/packages/grpc/src/index.ts
@@ -1,0 +1,4 @@
+export { GrpcService, GrpcServiceParameters } from "./grpcservice.js";
+export { GrpcStream, GrpcStatus } from "./grpc-stream.js";
+export type { GrpcMethodDef } from "./grpc-stream.js";
+export { generateProto } from "./proto-generator.js";

--- a/packages/grpc/src/proto-generator.spec.ts
+++ b/packages/grpc/src/proto-generator.spec.ts
@@ -1,0 +1,585 @@
+import { suite, test } from "@webda/test";
+import * as assert from "assert";
+import { generateProto } from "./proto-generator.js";
+import type { JSONSchema7 } from "json-schema";
+
+@suite
+class ProtoGeneratorTest {
+  @test
+  emptyOperations() {
+    const result = generateProto({}, {});
+    assert.ok(result.includes('syntax = "proto3"'));
+    assert.ok(result.includes("package webda;"));
+    assert.ok(result.includes('import "google/protobuf/empty.proto"'));
+    assert.ok(result.includes('import "google/protobuf/struct.proto"'));
+    // No services or messages
+    assert.ok(!result.includes("service "));
+    assert.ok(!result.includes("message "));
+  }
+
+  @test
+  customPackageName() {
+    const result = generateProto({}, {}, "myapp");
+    assert.ok(result.includes("package myapp;"));
+  }
+
+  @test
+  defaultPackageName() {
+    const result = generateProto({}, {});
+    assert.ok(result.includes("package webda;"));
+  }
+
+  @test
+  crudOperationsWithInputOutput() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Post": {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          body: { type: "string" }
+        }
+      },
+      "MyApp/PostResponse": {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          title: { type: "string" }
+        }
+      }
+    };
+
+    const operations = {
+      "Post.Create": {
+        input: "MyApp/Post",
+        output: "MyApp/PostResponse"
+      },
+      "Post.Get": {
+        output: "MyApp/PostResponse"
+      }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    // Should create PostService
+    assert.ok(result.includes("service PostService {"), "Should group into PostService");
+    // Should create Post and PostResponse messages
+    assert.ok(result.includes("message Post {"), "Should create Post message");
+    assert.ok(result.includes("message PostResponse {"), "Should create PostResponse message");
+    // Should create rpcs
+    assert.ok(result.includes("rpc Create(Post) returns (PostResponse);"), "Should create Create rpc");
+    assert.ok(result.includes("rpc Get(google.protobuf.Empty) returns (PostResponse);"), "Should create Get rpc with Empty input");
+  }
+
+  @test
+  hiddenOperationsAreSkipped() {
+    const operations = {
+      "Post.Create": {
+        input: "MyApp/Post",
+        hidden: true
+      },
+      "Post.Get": {
+        output: "MyApp/PostResponse"
+      }
+    };
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/PostResponse": {
+        type: "object",
+        properties: {
+          id: { type: "string" }
+        }
+      }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    // Hidden operations should not appear
+    assert.ok(!result.includes("rpc Create"), "Hidden operation Create should not appear");
+    // But visible ones should
+    assert.ok(result.includes("rpc Get"), "Visible operation Get should appear");
+  }
+
+  @test
+  serviceGroupingByPrefix() {
+    const operations = {
+      "Post.Create": {},
+      "Post.Get": {},
+      "User.Login": {},
+      "User.Logout": {}
+    };
+
+    const result = generateProto(operations, {});
+
+    assert.ok(result.includes("service PostService {"), "Should create PostService");
+    assert.ok(result.includes("service UserService {"), "Should create UserService");
+    assert.ok(result.includes("rpc Create(google.protobuf.Empty)"), "Should create Create rpc in PostService");
+    assert.ok(result.includes("rpc Get(google.protobuf.Empty)"), "Should create Get rpc in PostService");
+    assert.ok(result.includes("rpc Login(google.protobuf.Empty)"), "Should create Login rpc in UserService");
+    assert.ok(result.includes("rpc Logout(google.protobuf.Empty)"), "Should create Logout rpc in UserService");
+  }
+
+  @test
+  operationWithoutDotGoesToDefaultService() {
+    const operations = {
+      Health: {}
+    };
+
+    const result = generateProto(operations, {});
+    assert.ok(result.includes("service DefaultService {"), "Should create DefaultService for operations without a dot prefix");
+    assert.ok(result.includes("rpc Health(google.protobuf.Empty)"), "Should use opId as rpcName");
+  }
+
+  @test
+  emptyInputOutputUsesGoogleProtobufEmpty() {
+    const operations = {
+      "Post.List": {}
+    };
+
+    const result = generateProto(operations, {});
+    assert.ok(
+      result.includes("rpc List(google.protobuf.Empty) returns (google.protobuf.Empty);"),
+      "Should use google.protobuf.Empty for both input and output when none defined"
+    );
+  }
+
+  @test
+  streamingHints() {
+    const operations = {
+      "Stream.ServerPush": {
+        grpc: { streaming: "server" }
+      },
+      "Stream.ClientPush": {
+        grpc: { streaming: "client" }
+      },
+      "Stream.Bidi": {
+        grpc: { streaming: "bidi" }
+      },
+      "Stream.Unary": {}
+    };
+
+    const result = generateProto(operations, {});
+
+    assert.ok(
+      result.includes("rpc ServerPush(google.protobuf.Empty) returns (stream google.protobuf.Empty);"),
+      "Server streaming should have 'stream' on output"
+    );
+    assert.ok(
+      result.includes("rpc ClientPush(stream google.protobuf.Empty) returns (google.protobuf.Empty);"),
+      "Client streaming should have 'stream' on input"
+    );
+    assert.ok(
+      result.includes("rpc Bidi(stream google.protobuf.Empty) returns (stream google.protobuf.Empty);"),
+      "Bidi streaming should have 'stream' on both"
+    );
+    assert.ok(
+      result.includes("rpc Unary(google.protobuf.Empty) returns (google.protobuf.Empty);"),
+      "Unary should have no 'stream' keyword"
+    );
+  }
+
+  @test
+  messageGenerationFromJsonSchema() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Item": {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          count: { type: "number" },
+          price: { type: "number", format: "float" },
+          quantity: { type: "number", format: "int32" },
+          bigNum: { type: "number", format: "int64" },
+          active: { type: "boolean" },
+          rank: { type: "integer" },
+          bigRank: { type: "integer", format: "int64" }
+        }
+      }
+    };
+
+    const operations = {
+      "Item.Get": {
+        output: "MyApp/Item"
+      }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("message Item {"), "Should create Item message");
+    assert.ok(result.includes("string name = 1;"), "String field");
+    assert.ok(result.includes("double count = 2;"), "Number field defaults to double");
+    assert.ok(result.includes("float price = 3;"), "Float format");
+    assert.ok(result.includes("int32 quantity = 4;"), "Int32 format for number");
+    assert.ok(result.includes("int64 bigNum = 5;"), "Int64 format for number");
+    assert.ok(result.includes("bool active = 6;"), "Boolean field");
+    assert.ok(result.includes("int32 rank = 7;"), "Integer type defaults to int32");
+    assert.ok(result.includes("int64 bigRank = 8;"), "Integer with int64 format");
+  }
+
+  @test
+  stringFormats() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Dates": {
+        type: "object",
+        properties: {
+          created: { type: "string", format: "date-time" },
+          birthday: { type: "string", format: "date" },
+          bigId: { type: "string", format: "int64" },
+          plain: { type: "string" }
+        }
+      }
+    };
+
+    const operations = {
+      "Date.Get": { output: "MyApp/Dates" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("string created = 1;"), "date-time maps to string");
+    assert.ok(result.includes("string birthday = 2;"), "date maps to string");
+    assert.ok(result.includes("int64 bigId = 3;"), "string with int64 format maps to int64");
+    assert.ok(result.includes("string plain = 4;"), "plain string");
+  }
+
+  @test
+  nestedObjectMessage() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Container": {
+        type: "object",
+        properties: {
+          label: { type: "string" },
+          metadata: {
+            type: "object",
+            properties: {
+              key: { type: "string" },
+              value: { type: "string" }
+            }
+          }
+        }
+      }
+    };
+
+    const operations = {
+      "Container.Get": { output: "MyApp/Container" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("message Container {"), "Should create Container message");
+    assert.ok(result.includes("message ContainerMetadata {"), "Should create nested ContainerMetadata message");
+    assert.ok(result.includes("ContainerMetadata metadata = 2;"), "Should reference nested message type");
+    assert.ok(result.includes("string key = 1;"), "Nested message should have fields");
+    assert.ok(result.includes("string value = 2;"), "Nested message should have fields");
+  }
+
+  @test
+  objectWithoutPropertiesUsesStruct() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Dynamic": {
+        type: "object",
+        properties: {
+          data: { type: "object" } // no properties => Struct
+        }
+      }
+    };
+
+    const operations = {
+      "Dynamic.Get": { output: "MyApp/Dynamic" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("google.protobuf.Struct data = 1;"), "Object without properties maps to Struct");
+  }
+
+  @test
+  arrayField() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/List": {
+        type: "object",
+        properties: {
+          items: {
+            type: "array",
+            items: { type: "string" }
+          },
+          numbers: {
+            type: "array",
+            items: { type: "integer" }
+          }
+        }
+      }
+    };
+
+    const operations = {
+      "List.Get": { output: "MyApp/List" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("repeated string items = 1;"), "Array of strings should be repeated string");
+    assert.ok(result.includes("repeated int32 numbers = 2;"), "Array of integers should be repeated int32");
+  }
+
+  @test
+  refField() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Order": {
+        type: "object",
+        properties: {
+          item: { $ref: "#/definitions/MyApp/Item" }
+        }
+      },
+      "MyApp/Item": {
+        type: "object",
+        properties: {
+          name: { type: "string" }
+        }
+      }
+    };
+
+    const operations = {
+      "Order.Get": { output: "MyApp/Order" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("Item item = 1;"), "Ref should resolve to message name");
+  }
+
+  @test
+  componentsSchemaRef() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Widget": {
+        type: "object",
+        properties: {
+          part: { $ref: "#/components/schemas/MyApp/Part" }
+        }
+      }
+    };
+
+    const operations = {
+      "Widget.Get": { output: "MyApp/Widget" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("Part part = 1;"), "Components schema ref should resolve");
+  }
+
+  @test
+  operationWithSummary() {
+    const operations = {
+      "Post.Create": {
+        summary: "Create a new post"
+      }
+    };
+
+    const result = generateProto(operations, {});
+
+    assert.ok(result.includes("// Create a new post"), "Summary should appear as comment before rpc");
+  }
+
+  @test
+  operationWithParametersSchema() {
+    const schemas: Record<string, JSONSchema7> = {
+      uuidRequest: {
+        type: "object",
+        properties: {
+          uuid: { type: "string" }
+        }
+      }
+    };
+
+    const operations = {
+      "Post.Get": {
+        parameters: "uuidRequest",
+        output: "MyApp/PostResponse"
+      }
+    };
+
+    const schemasWithOutput: Record<string, JSONSchema7> = {
+      ...schemas,
+      "MyApp/PostResponse": {
+        type: "object",
+        properties: {
+          id: { type: "string" }
+        }
+      }
+    };
+
+    const result = generateProto(operations, schemasWithOutput);
+
+    // Parameters should become the input type when no explicit input
+    assert.ok(result.includes("message UuidRequest {"), "Should create message from parameters schema");
+    assert.ok(result.includes("rpc Get(UuidRequest) returns (PostResponse);"), "Should use parameters as input type");
+  }
+
+  @test
+  inputTakesPriorityOverParameters() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/CreateInput": {
+        type: "object",
+        properties: { title: { type: "string" } }
+      },
+      uuidParams: {
+        type: "object",
+        properties: { uuid: { type: "string" } }
+      }
+    };
+
+    const operations = {
+      "Post.Create": {
+        input: "MyApp/CreateInput",
+        parameters: "uuidParams"
+      }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    // input should win over parameters
+    assert.ok(result.includes("rpc Create(CreateInput)"), "Input should take priority over parameters");
+  }
+
+  @test
+  schemaToMessageNameHandlesSlashAndDotNotation() {
+    const schemas: Record<string, JSONSchema7> = {
+      "WebdaSample/Post": {
+        type: "object",
+        properties: { title: { type: "string" } }
+      },
+      "my.nested.schema": {
+        type: "object",
+        properties: { value: { type: "string" } }
+      }
+    };
+
+    const operations = {
+      "Post.Get": { output: "WebdaSample/Post" },
+      "Nested.Get": { output: "my.nested.schema" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    // "WebdaSample/Post" → "Post"
+    assert.ok(result.includes("message Post {"), "Slash-separated should use last segment");
+    // "my.nested.schema" → "MyNestedSchema"
+    assert.ok(result.includes("message MyNestedSchema {"), "Dot-separated should be PascalCased and joined");
+  }
+
+  @test
+  unknownTypeDefaultsToStruct() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Mystery": {
+        type: "object",
+        properties: {
+          unknownField: {} // no type at all
+        }
+      }
+    };
+
+    const operations = {
+      "Mystery.Get": { output: "MyApp/Mystery" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("google.protobuf.Struct unknownField = 1;"), "Unknown type should default to Struct");
+  }
+
+  @test
+  arrayWithoutItemsDefaultsToStruct() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Flexible": {
+        type: "object",
+        properties: {
+          tags: {
+            type: "array"
+            // no items defined
+          }
+        }
+      }
+    };
+
+    const operations = {
+      "Flexible.Get": { output: "MyApp/Flexible" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    // Array without items should use Struct as the element type
+    assert.ok(result.includes("repeated google.protobuf.Struct tags = 1;"), "Array without items should repeat Struct");
+  }
+
+  @test
+  numberIntegerFormat() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/NumTypes": {
+        type: "object",
+        properties: {
+          intField: { type: "number", format: "integer" }
+        }
+      }
+    };
+
+    const operations = {
+      "NumTypes.Get": { output: "MyApp/NumTypes" }
+    };
+
+    const result = generateProto(operations, schemas);
+
+    assert.ok(result.includes("int32 intField = 1;"), "Number with 'integer' format maps to int32");
+  }
+
+  @test
+  arrayTypeInJsonTypeToProtoRecursion() {
+    const schemas: Record<string, JSONSchema7> = {
+      "MyApp/Nested": {
+        type: "object",
+        properties: {
+          matrix: {
+            type: "array",
+            items: {
+              type: "array",
+              items: { type: "integer" }
+            }
+          }
+        }
+      }
+    };
+
+    const operations = {
+      "Nested.Get": { output: "MyApp/Nested" }
+    };
+
+    // This exercises the "array" case within jsonTypeToProto
+    const result = generateProto(operations, schemas);
+    // The outer array items is an array of integers
+    // jsonTypeToProto for "array" type recurses into items
+    assert.ok(result.includes("repeated int32 matrix = 1;"), "Nested array should recurse into items");
+  }
+
+  @test
+  operationWithInputSchemaNotInSchemas() {
+    const operations = {
+      "Post.Create": {
+        input: "MyApp/NonExistent"
+      }
+    };
+
+    const result = generateProto(operations, {});
+
+    // If schema not found, should use Empty
+    assert.ok(result.includes("rpc Create(google.protobuf.Empty)"), "Missing schema should fall back to Empty");
+  }
+
+  @test
+  operationWithOutputSchemaNotInSchemas() {
+    const operations = {
+      "Post.Get": {
+        output: "MyApp/NonExistent"
+      }
+    };
+
+    const result = generateProto(operations, {});
+
+    assert.ok(result.includes("returns (google.protobuf.Empty)"), "Missing output schema should fall back to Empty");
+  }
+}

--- a/packages/grpc/src/proto-generator.ts
+++ b/packages/grpc/src/proto-generator.ts
@@ -38,7 +38,7 @@ export function generateProto(
     if (!serviceGroups.has(prefix)) {
       serviceGroups.set(prefix, []);
     }
-    serviceGroups.get(prefix).push({ opId, op, rpcName });
+    serviceGroups.get(prefix)!.push({ opId, op, rpcName });
   }
 
   // Generate messages for all referenced schemas
@@ -100,7 +100,7 @@ export function generateProto(
  * @returns the PascalCase protobuf message name derived from the reference
  */
 function schemaToMessageName(schemaRef: string): string {
-  const name = schemaRef.includes("/") ? schemaRef.split("/").pop() : schemaRef;
+  const name = (schemaRef.includes("/") ? schemaRef.split("/").pop() : schemaRef) ?? schemaRef;
   // Remove dots and capitalize
   return name
     .split(".")

--- a/packages/grpc/src/proto-generator.ts
+++ b/packages/grpc/src/proto-generator.ts
@@ -1,0 +1,245 @@
+import type { OperationDefinition } from "@webda/core";
+import type { JSONSchema7 } from "json-schema";
+
+/**
+ * Generate a .proto file from registered operations and their schemas.
+ *
+ * Groups operations by prefix (e.g., "Post.Create" → service PostService)
+ * and converts JSON Schema input/output types to protobuf messages.
+ * @param operations - map of operation IDs to their definitions
+ * @param schemas - all known JSON schemas keyed by schema reference name
+ * @param packageName - protobuf package name to use in the generated file
+ * @returns the complete .proto file content as a string
+ */
+export function generateProto(
+  operations: Record<string, Omit<OperationDefinition, "service" | "method">>,
+  schemas: Record<string, JSONSchema7>,
+  packageName: string = "webda"
+): string {
+  const lines: string[] = [];
+  const messages = new Map<string, string>(); // messageName → proto definition
+  const fieldCounter = 0;
+
+  lines.push('syntax = "proto3";');
+  lines.push("");
+  lines.push(`package ${packageName};`);
+  lines.push("");
+  lines.push('import "google/protobuf/empty.proto";');
+  lines.push('import "google/protobuf/struct.proto";');
+  lines.push("");
+
+  // Group operations by service prefix
+  const serviceGroups = new Map<string, { opId: string; op: any; rpcName: string }[]>();
+  for (const [opId, op] of Object.entries(operations)) {
+    if (op.hidden) continue;
+    const dotIdx = opId.indexOf(".");
+    const prefix = dotIdx > 0 ? opId.substring(0, dotIdx) : "Default";
+    const rpcName = dotIdx > 0 ? opId.substring(dotIdx + 1) : opId;
+    if (!serviceGroups.has(prefix)) {
+      serviceGroups.set(prefix, []);
+    }
+    serviceGroups.get(prefix).push({ opId, op, rpcName });
+  }
+
+  // Generate messages for all referenced schemas
+  for (const [opId, op] of Object.entries(operations)) {
+    if (op.hidden) continue;
+    if (op.input && schemas[op.input]) {
+      const msgName = schemaToMessageName(op.input);
+      if (!messages.has(msgName)) {
+        messages.set(msgName, jsonSchemaToMessage(msgName, schemas[op.input], schemas, messages));
+      }
+    }
+    if (op.output && schemas[op.output]) {
+      const msgName = schemaToMessageName(op.output);
+      if (!messages.has(msgName)) {
+        messages.set(msgName, jsonSchemaToMessage(msgName, schemas[op.output], schemas, messages));
+      }
+    }
+    if (op.parameters && schemas[op.parameters]) {
+      const msgName = schemaToMessageName(op.parameters);
+      if (!messages.has(msgName)) {
+        messages.set(msgName, jsonSchemaToMessage(msgName, schemas[op.parameters], schemas, messages));
+      }
+    }
+  }
+
+  // Write all messages
+  for (const [, msgDef] of messages) {
+    lines.push(msgDef);
+    lines.push("");
+  }
+
+  // Write services
+  for (const [prefix, ops] of serviceGroups) {
+    lines.push(`service ${prefix}Service {`);
+    for (const { opId, op, rpcName } of ops) {
+      const inputType = getInputType(op, schemas, messages);
+      const outputType = getOutputType(op, schemas, messages);
+      const streaming = op.grpc?.streaming || "none";
+
+      const inputMod = streaming === "client" || streaming === "bidi" ? "stream " : "";
+      const outputMod = streaming === "server" || streaming === "bidi" ? "stream " : "";
+
+      if (op.summary) {
+        lines.push(`  // ${op.summary}`);
+      }
+      lines.push(`  rpc ${rpcName}(${inputMod}${inputType}) returns (${outputMod}${outputType});`);
+    }
+    lines.push("}");
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Convert a schema reference name to a protobuf message name.
+ * "WebdaSample/Post" → "Post", "uuidRequest" → "UuidRequest"
+ * @param schemaRef - the schema reference string, e.g. "MyApp/Post" or "uuidRequest"
+ * @returns the PascalCase protobuf message name derived from the reference
+ */
+function schemaToMessageName(schemaRef: string): string {
+  const name = schemaRef.includes("/") ? schemaRef.split("/").pop() : schemaRef;
+  // Remove dots and capitalize
+  return name
+    .split(".")
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+    .join("");
+}
+
+/**
+ * Get the protobuf input type for an operation.
+ * Merges parameters + input into a single request message if both exist.
+ * @param op - the operation definition containing optional input and parameters schema references
+ * @param schemas - all known JSON schemas keyed by schema reference name
+ * @param messages - accumulator map of already-generated protobuf message definitions
+ * @returns the protobuf type name to use as the RPC input type
+ */
+function getInputType(
+  op: any,
+  schemas: Record<string, JSONSchema7>,
+  messages: Map<string, string>
+): string {
+  if (op.input && schemas[op.input]) {
+    return schemaToMessageName(op.input);
+  }
+  if (op.parameters && schemas[op.parameters]) {
+    return schemaToMessageName(op.parameters);
+  }
+  return "google.protobuf.Empty";
+}
+
+/**
+ * Get the protobuf output type for an operation.
+ * @param op - the operation definition containing an optional output schema reference
+ * @param schemas - all known JSON schemas keyed by schema reference name
+ * @param messages - accumulator map of already-generated protobuf message definitions
+ * @returns the protobuf type name to use as the RPC output type
+ */
+function getOutputType(
+  op: any,
+  schemas: Record<string, JSONSchema7>,
+  messages: Map<string, string>
+): string {
+  if (op.output && schemas[op.output]) {
+    return schemaToMessageName(op.output);
+  }
+  return "google.protobuf.Empty";
+}
+
+/**
+ * Convert a JSON Schema object to a protobuf message definition.
+ * @param name - the protobuf message name to assign to this definition
+ * @param schema - the JSON Schema object describing the message fields
+ * @param allSchemas - all known JSON schemas, used to resolve nested references
+ * @param messages - accumulator map updated with any nested message definitions generated
+ * @returns the protobuf message block as a string
+ */
+function jsonSchemaToMessage(
+  name: string,
+  schema: JSONSchema7,
+  allSchemas: Record<string, JSONSchema7>,
+  messages: Map<string, string>
+): string {
+  const lines: string[] = [];
+  lines.push(`message ${name} {`);
+
+  if (schema.properties) {
+    let fieldNum = 1;
+    for (const [propName, propSchema] of Object.entries(schema.properties)) {
+      const prop = propSchema as JSONSchema7;
+      const protoType = jsonTypeToProto(propName, prop, name, allSchemas, messages);
+      const repeated = prop.type === "array" ? "repeated " : "";
+      const fieldType = prop.type === "array" ? jsonTypeToProto(propName, (prop.items as JSONSchema7) || {}, name, allSchemas, messages) : protoType;
+      if (prop.type === "array") {
+        lines.push(`  repeated ${fieldType} ${propName} = ${fieldNum};`);
+      } else {
+        lines.push(`  ${protoType} ${propName} = ${fieldNum};`);
+      }
+      fieldNum++;
+    }
+  }
+
+  lines.push("}");
+  return lines.join("\n");
+}
+
+/**
+ * Map a JSON Schema type to a protobuf type.
+ * @param fieldName - the property name in the parent schema, used to derive nested message names
+ * @param schema - the JSON Schema describing this field's type
+ * @param parentName - the name of the enclosing protobuf message, used for nested message naming
+ * @param allSchemas - all known JSON schemas, used to resolve nested references
+ * @param messages - accumulator map updated with any nested message definitions generated
+ * @returns the protobuf scalar or message type name for this field
+ */
+function jsonTypeToProto(
+  fieldName: string,
+  schema: JSONSchema7,
+  parentName: string,
+  allSchemas: Record<string, JSONSchema7>,
+  messages: Map<string, string>
+): string {
+  if (schema.$ref) {
+    const refName = schema.$ref.replace("#/definitions/", "").replace("#/components/schemas/", "");
+    return schemaToMessageName(refName);
+  }
+
+  switch (schema.type) {
+    case "string":
+      if (schema.format === "date-time" || schema.format === "date") return "string"; // Timestamps as ISO strings
+      if (schema.format === "int64") return "int64";
+      return "string";
+    case "number":
+      if (schema.format === "float") return "float";
+      if (schema.format === "int32" || schema.format === "integer") return "int32";
+      if (schema.format === "int64") return "int64";
+      return "double";
+    case "integer":
+      if (schema.format === "int64") return "int64";
+      return "int32";
+    case "boolean":
+      return "bool";
+    case "object":
+      if (schema.properties) {
+        // Nested message
+        const nestedName = `${parentName}${fieldName.charAt(0).toUpperCase() + fieldName.slice(1)}`;
+        if (!messages.has(nestedName)) {
+          messages.set(nestedName, jsonSchemaToMessage(nestedName, schema, allSchemas, messages));
+        }
+        return nestedName;
+      }
+      return "google.protobuf.Struct";
+    case "array":
+      // Handled by caller
+      return jsonTypeToProto(fieldName, (schema.items as JSONSchema7) || {}, parentName, allSchemas, messages);
+    default:
+      return "google.protobuf.Struct";
+  }
+
+  // Enum support
+  if (schema.enum) {
+    return "string"; // Map enums to strings for simplicity
+  }
+}

--- a/packages/grpc/tsconfig.json
+++ b/packages/grpc/tsconfig.json
@@ -1,11 +1,33 @@
 {
-  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "lib",
-    "rootDir": "src",
+    "target": "ES2022",
+    "module": "nodenext",
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": false,
     "declaration": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "isolatedModules": true,
+    "experimentalDecorators": false,
+    "esModuleInterop": true,
+    "moduleResolution": "nodenext",
+    "skipLibCheck": true,
+    "declarationMap": true,
+    "useDefineForClassFields": true,
+    "strictPropertyInitialization": false,
+    "lib": [
+      "ES2022",
+      "ESNext.Decorators"
+    ],
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.spec.ts", "node_modules", "lib"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "**/node_modules",
+    "src/**/*.spec.ts"
+  ]
 }

--- a/packages/grpc/tsconfig.json
+++ b/packages/grpc/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "lib",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.spec.ts", "node_modules", "lib"]
+}

--- a/packages/grpc/vitest.config.ts
+++ b/packages/grpc/vitest.config.ts
@@ -1,0 +1,20 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  clearScreen: false,
+  test: {
+    allowOnly: true,
+    testTimeout: 20000,
+    coverage: {
+      enabled: true,
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/*.spec.ts", "src/index.ts"],
+      reporter: ["lcov", "html", "text"]
+    },
+    reporters: "verbose",
+    include: ["src/**/*.spec.ts"]
+  }
+});

--- a/packages/grpc/webda.module.json
+++ b/packages/grpc/webda.module.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://webda.io/schemas/webda.module.v4.json",
+  "beans": {},
+  "deployers": {},
+  "moddas": {
+    "Webda/GrpcService": {
+      "Import": "lib/grpcservice:default",
+      "Schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "Parameters for the gRPC service",
+        "properties": {
+          "operations": {
+            "default": [
+              "*"
+            ],
+            "description": "List of operations to include/exclude\nSupports wildcards and negation: [\"*\", \"!User.Delete\"]",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "packageName": {
+            "default": "webda",
+            "description": "Protobuf package name",
+            "type": "string"
+          },
+          "protoFile": {
+            "default": ".webda/app.proto",
+            "description": "Path to the generated .proto file",
+            "type": "string"
+          },
+          "type": {
+            "description": "Type of the service",
+            "type": "string"
+          },
+          "openapi": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "type"
+        ],
+        "type": "object",
+        "title": "GrpcService"
+      },
+      "Configuration": "lib/grpcservice:GrpcServiceParameters",
+      "commands": {
+        "generate-proto": {
+          "description": "Generate protobuf definition from operations",
+          "method": "generateProto",
+          "args": {
+            "output": {
+              "type": "string",
+              "alias": "o",
+              "description": "Output file path"
+            }
+          },
+          "requires": [
+            "rest-domain"
+          ]
+        }
+      }
+    }
+  },
+  "models": {},
+  "schemas": {
+    "Webda/BinaryFile": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "WebdaSchema": true,
+      "additionalProperties": false,
+      "description": "Represent a file to store",
+      "properties": {
+        "challenge": {
+          "description": "Will be computed by the service\n\nhash of the content prefixed by 'WEBDA'",
+          "type": "string"
+        },
+        "hash": {
+          "description": "Will be computed by the service\n\nhash of the content",
+          "type": "string"
+        },
+        "metadata": {
+          "description": "Metadatas stored along with the binary"
+        },
+        "mimetype": {
+          "description": "Mimetype of the binary",
+          "type": "string"
+        },
+        "name": {
+          "description": "Current name",
+          "type": "string"
+        },
+        "originalname": {
+          "description": "Original name",
+          "type": "string"
+        },
+        "size": {
+          "description": "Size of the binary",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mimetype",
+        "name",
+        "size"
+      ],
+      "type": "object",
+      "title": "BinaryFile"
+    }
+  },
+  "capabilities": {
+    "grpc": "Webda/GrpcService"
+  }
+}

--- a/sample-apps/blog-system/webda.config.json
+++ b/sample-apps/blog-system/webda.config.json
@@ -13,6 +13,11 @@
     },
     "RESTService": {
       "type": "Webda/RESTOperationsTransport"
+    },
+    "WebUI": {
+      "type": "Webda/ResourceService",
+      "folder": "./webui",
+      "url": "/admin"
     }
   }
 }

--- a/sample-apps/blog-system/webui/api.js
+++ b/sample-apps/blog-system/webui/api.js
@@ -1,0 +1,65 @@
+/**
+ * API client for the blog-system REST endpoints.
+ * All methods return parsed JSON or throw on error.
+ */
+
+const BASE = "";
+
+async function request(method, path, body) {
+  const opts = { method, headers: {} };
+  if (body !== undefined) {
+    if (body instanceof FormData) {
+      opts.body = body;
+    } else {
+      opts.headers["Content-Type"] = "application/json";
+      opts.body = JSON.stringify(body);
+    }
+  }
+  const res = await fetch(`${BASE}${path}`, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`${res.status}: ${text || res.statusText}`);
+  }
+  const text = await res.text();
+  if (!text) return null;
+  try { return JSON.parse(text); } catch { return text; }
+}
+
+// Posts
+export const posts = {
+  list: (q = "") => request("PUT", "/posts", { q }),
+  get: (slug) => request("GET", `/posts/${slug}`),
+  create: (data) => request("POST", "/posts", data),
+  update: (slug, data) => request("PUT", `/posts/${slug}`, data),
+  patch: (slug, data) => request("PATCH", `/posts/${slug}`, data),
+  delete: (slug) => request("DELETE", `/posts/${slug}`),
+  publish: (slug, destination) => request("PUT", `/posts/${slug}/publish`, { destination }),
+};
+
+// Users
+export const users = {
+  list: (q = "") => request("PUT", "/users", { q }),
+  get: (uuid) => request("GET", `/users/${uuid}`),
+  create: (data) => request("POST", "/users", data),
+  update: (uuid, data) => request("PUT", `/users/${uuid}`, data),
+  patch: (uuid, data) => request("PATCH", `/users/${uuid}`, data),
+  delete: (uuid) => request("DELETE", `/users/${uuid}`),
+};
+
+// Tags
+export const tags = {
+  list: (q = "") => request("PUT", "/tags", { q }),
+  get: (slug) => request("GET", `/tags/${slug}`),
+  create: (data) => request("POST", "/tags", data),
+  update: (slug, data) => request("PUT", `/tags/${slug}`, data),
+  delete: (slug) => request("DELETE", `/tags/${slug}`),
+};
+
+// Comments
+export const comments = {
+  list: (q = "") => request("PUT", "/comments", { q }),
+  get: (uuid) => request("GET", `/comments/${uuid}`),
+  create: (data) => request("POST", "/comments", data),
+  update: (uuid, data) => request("PUT", `/comments/${uuid}`, data),
+  delete: (uuid) => request("DELETE", `/comments/${uuid}`),
+};

--- a/sample-apps/blog-system/webui/app.js
+++ b/sample-apps/blog-system/webui/app.js
@@ -1,0 +1,59 @@
+import { h, render } from "https://esm.sh/preact@10.25.4";
+import { useState, useCallback } from "https://esm.sh/preact@10.25.4/hooks";
+import htm from "https://esm.sh/htm@3.1.1";
+import { PostsPanel } from "./components/posts.js";
+import { UsersPanel } from "./components/users.js";
+import { TagsPanel } from "./components/tags.js";
+import { CommentsPanel } from "./components/comments.js";
+
+const html = htm.bind(h);
+
+const TABS = [
+  { id: "posts", label: "Posts" },
+  { id: "users", label: "Users" },
+  { id: "tags", label: "Tags" },
+  { id: "comments", label: "Comments" },
+];
+
+function Toast({ message, type, onDone }) {
+  if (!message) return null;
+  setTimeout(onDone, 3000);
+  return html`<div class="toast toast-${type}">${message}</div>`;
+}
+
+function App() {
+  const [tab, setTab] = useState("posts");
+  const [toast, setToast] = useState(null);
+
+  const notify = useCallback((message, type = "success") => {
+    setToast({ message, type });
+  }, []);
+
+  const clearToast = useCallback(() => setToast(null), []);
+
+  return html`
+    <div class="app">
+      <div class="header">
+        <h1><span>Blog</span> Admin</h1>
+        <div class="nav">
+          ${TABS.map(t => html`
+            <button
+              key=${t.id}
+              class=${tab === t.id ? "active" : ""}
+              onClick=${() => setTab(t.id)}
+            >${t.label}</button>
+          `)}
+        </div>
+      </div>
+      <div class="content">
+        ${tab === "posts" && html`<${PostsPanel} notify=${notify} />`}
+        ${tab === "users" && html`<${UsersPanel} notify=${notify} />`}
+        ${tab === "tags" && html`<${TagsPanel} notify=${notify} />`}
+        ${tab === "comments" && html`<${CommentsPanel} notify=${notify} />`}
+      </div>
+      ${toast && html`<${Toast} message=${toast.message} type=${toast.type} onDone=${clearToast} />`}
+    </div>
+  `;
+}
+
+render(html`<${App} />`, document.getElementById("app"));

--- a/sample-apps/blog-system/webui/components/comments.js
+++ b/sample-apps/blog-system/webui/components/comments.js
@@ -1,0 +1,127 @@
+import { h } from "https://esm.sh/preact@10.25.4";
+import { useState, useEffect } from "https://esm.sh/preact@10.25.4/hooks";
+import htm from "https://esm.sh/htm@3.1.1";
+import { comments } from "../api.js";
+
+const html = htm.bind(h);
+
+function CommentForm({ initial, onSave, onCancel }) {
+  const [form, setForm] = useState(initial || { content: "" });
+  const set = (k, v) => setForm({ ...form, [k]: v });
+
+  return html`
+    <div class="modal-overlay" onClick=${(e) => e.target === e.currentTarget && onCancel()}>
+      <div class="modal">
+        <h2>${initial ? "Edit Comment" : "New Comment"}</h2>
+        <div class="form-group">
+          <label>Content</label>
+          <textarea rows="4" value=${form.content} onInput=${(e) => set("content", e.target.value)} placeholder="Comment text (1-2000 chars)" />
+        </div>
+        <div class="modal-actions">
+          <button class="btn btn-ghost" onClick=${onCancel}>Cancel</button>
+          <button class="btn btn-primary" onClick=${() => onSave(form)}>
+            ${initial ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function formatDate(ts) {
+  if (!ts) return "-";
+  return new Date(ts).toLocaleString();
+}
+
+export function CommentsPanel({ notify }) {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [editing, setEditing] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await comments.list(filter);
+      setItems(res?.results || []);
+    } catch (e) {
+      notify(e.message, "error");
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, [filter]);
+
+  const handleSave = async (form) => {
+    try {
+      if (editing === "new") {
+        await comments.create(form);
+        notify("Comment created");
+      } else {
+        await comments.patch(editing.uuid, form);
+        notify("Comment updated");
+      }
+      setEditing(null);
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  const handleDelete = async (uuid) => {
+    if (!confirm("Delete this comment?")) return;
+    try {
+      await comments.delete(uuid);
+      notify("Comment deleted");
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  return html`
+    <div>
+      <div class="toolbar">
+        <input placeholder="Search comments..." value=${filter} onInput=${(e) => setFilter(e.target.value)} />
+        <button class="btn btn-primary" onClick=${() => setEditing("new")}>+ New Comment</button>
+        <button class="btn btn-ghost" onClick=${load}>Refresh</button>
+      </div>
+      ${items.length === 0 ? html`
+        <div class="empty">${loading ? "Loading..." : "No comments yet."}</div>
+      ` : html`
+        <table>
+          <thead>
+            <tr>
+              <th style="width:80px">ID</th>
+              <th>Content</th>
+              <th>Edited</th>
+              <th>Created</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map(c => html`
+              <tr key=${c.uuid}>
+                <td class="mono" style="font-size:0.75rem;color:var(--text-muted)">${(c.uuid || "").substring(0, 8)}...</td>
+                <td style="max-width:400px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${c.content}</td>
+                <td>${c.isEdited ? html`<span class="badge badge-yellow">edited</span>` : "-"}</td>
+                <td style="color:var(--text-muted);font-size:0.8125rem">${formatDate(c.createdAt)}</td>
+                <td>
+                  <button class="btn btn-ghost btn-sm" onClick=${() => setEditing(c)}>Edit</button>
+                  <button class="btn btn-danger btn-sm" style="margin-left:4px" onClick=${() => handleDelete(c.uuid)}>Delete</button>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      `}
+      ${editing !== null && html`
+        <${CommentForm}
+          initial=${editing === "new" ? null : editing}
+          onSave=${handleSave}
+          onCancel=${() => setEditing(null)}
+        />
+      `}
+    </div>
+  `;
+}

--- a/sample-apps/blog-system/webui/components/posts.js
+++ b/sample-apps/blog-system/webui/components/posts.js
@@ -1,0 +1,148 @@
+import { h } from "https://esm.sh/preact@10.25.4";
+import { useState, useEffect } from "https://esm.sh/preact@10.25.4/hooks";
+import htm from "https://esm.sh/htm@3.1.1";
+import { posts } from "../api.js";
+
+const html = htm.bind(h);
+
+function PostForm({ initial, onSave, onCancel }) {
+  const [form, setForm] = useState(initial || {
+    title: "", slug: "", content: "", excerpt: "", status: "draft", viewCount: 0
+  });
+  const set = (k, v) => setForm({ ...form, [k]: v });
+
+  return html`
+    <div class="modal-overlay" onClick=${(e) => e.target === e.currentTarget && onCancel()}>
+      <div class="modal">
+        <h2>${initial ? "Edit Post" : "New Post"}</h2>
+        <div class="form-group">
+          <label>Title</label>
+          <input value=${form.title} onInput=${(e) => set("title", e.target.value)} placeholder="Post title (5-200 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Slug</label>
+          <input value=${form.slug} onInput=${(e) => set("slug", e.target.value)} placeholder="url-friendly-slug" ${initial ? "disabled" : ""} />
+        </div>
+        <div class="form-group">
+          <label>Content</label>
+          <textarea rows="6" value=${form.content} onInput=${(e) => set("content", e.target.value)} placeholder="Markdown content (min 10 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Excerpt</label>
+          <input value=${form.excerpt || ""} onInput=${(e) => set("excerpt", e.target.value)} placeholder="Short excerpt (max 500 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Status</label>
+          <select value=${form.status} onChange=${(e) => set("status", e.target.value)}>
+            <option value="draft">Draft</option>
+            <option value="published">Published</option>
+            <option value="archived">Archived</option>
+          </select>
+        </div>
+        <div class="modal-actions">
+          <button class="btn btn-ghost" onClick=${onCancel}>Cancel</button>
+          <button class="btn btn-primary" onClick=${() => onSave(form)}>
+            ${initial ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function PostsPanel({ notify }) {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [editing, setEditing] = useState(null); // null | "new" | post object
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await posts.list(filter);
+      setItems(res?.results || []);
+    } catch (e) {
+      notify(e.message, "error");
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, [filter]);
+
+  const handleSave = async (form) => {
+    try {
+      if (editing === "new") {
+        await posts.create(form);
+        notify("Post created");
+      } else {
+        await posts.patch(editing.slug, form);
+        notify("Post updated");
+      }
+      setEditing(null);
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  const handleDelete = async (slug) => {
+    if (!confirm(`Delete post "${slug}"?`)) return;
+    try {
+      await posts.delete(slug);
+      notify("Post deleted");
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  return html`
+    <div>
+      <div class="toolbar">
+        <input placeholder="Search posts..." value=${filter} onInput=${(e) => setFilter(e.target.value)} />
+        <button class="btn btn-primary" onClick=${() => setEditing("new")}>+ New Post</button>
+        <button class="btn btn-ghost" onClick=${load}>Refresh</button>
+      </div>
+      ${items.length === 0 ? html`
+        <div class="empty">${loading ? "Loading..." : "No posts yet. Create one!"}</div>
+      ` : html`
+        <table>
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Slug</th>
+              <th>Status</th>
+              <th>Views</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map(p => html`
+              <tr key=${p.slug}>
+                <td>${p.title}</td>
+                <td class="mono">${p.slug}</td>
+                <td>
+                  <span class="badge ${p.status === "published" ? "badge-green" : p.status === "draft" ? "badge-yellow" : "badge-red"}">
+                    ${p.status}
+                  </span>
+                </td>
+                <td>${p.viewCount || 0}</td>
+                <td>
+                  <button class="btn btn-ghost btn-sm" onClick=${() => setEditing(p)}>Edit</button>
+                  <button class="btn btn-danger btn-sm" style="margin-left:4px" onClick=${() => handleDelete(p.slug)}>Delete</button>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      `}
+      ${editing !== null && html`
+        <${PostForm}
+          initial=${editing === "new" ? null : editing}
+          onSave=${handleSave}
+          onCancel=${() => setEditing(null)}
+        />
+      `}
+    </div>
+  `;
+}

--- a/sample-apps/blog-system/webui/components/tags.js
+++ b/sample-apps/blog-system/webui/components/tags.js
@@ -1,0 +1,139 @@
+import { h } from "https://esm.sh/preact@10.25.4";
+import { useState, useEffect } from "https://esm.sh/preact@10.25.4/hooks";
+import htm from "https://esm.sh/htm@3.1.1";
+import { tags } from "../api.js";
+
+const html = htm.bind(h);
+
+function TagForm({ initial, onSave, onCancel }) {
+  const [form, setForm] = useState(initial || {
+    name: "", slug: "", description: "", color: "#4f8ff7"
+  });
+  const set = (k, v) => setForm({ ...form, [k]: v });
+
+  return html`
+    <div class="modal-overlay" onClick=${(e) => e.target === e.currentTarget && onCancel()}>
+      <div class="modal">
+        <h2>${initial ? "Edit Tag" : "New Tag"}</h2>
+        <div class="form-group">
+          <label>Name</label>
+          <input value=${form.name} onInput=${(e) => set("name", e.target.value)} placeholder="Tag name (2-30 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Slug</label>
+          <input value=${form.slug} onInput=${(e) => set("slug", e.target.value)} placeholder="tag-slug" ${initial ? "disabled" : ""} />
+        </div>
+        <div class="form-group">
+          <label>Description</label>
+          <input value=${form.description || ""} onInput=${(e) => set("description", e.target.value)} placeholder="Short description (max 200 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Color</label>
+          <div style="display:flex;gap:0.5rem;align-items:center">
+            <input type="color" value=${form.color || "#4f8ff7"} onInput=${(e) => set("color", e.target.value)} style="width:40px;height:32px;padding:2px;cursor:pointer" />
+            <input value=${form.color || ""} onInput=${(e) => set("color", e.target.value)} placeholder="#4f8ff7" style="flex:1" />
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button class="btn btn-ghost" onClick=${onCancel}>Cancel</button>
+          <button class="btn btn-primary" onClick=${() => onSave(form)}>
+            ${initial ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function TagsPanel({ notify }) {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [editing, setEditing] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await tags.list(filter);
+      setItems(res?.results || []);
+    } catch (e) {
+      notify(e.message, "error");
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, [filter]);
+
+  const handleSave = async (form) => {
+    try {
+      if (editing === "new") {
+        await tags.create(form);
+        notify("Tag created");
+      } else {
+        await tags.patch(editing.slug, form);
+        notify("Tag updated");
+      }
+      setEditing(null);
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  const handleDelete = async (slug) => {
+    if (!confirm(`Delete tag "${slug}"?`)) return;
+    try {
+      await tags.delete(slug);
+      notify("Tag deleted");
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  return html`
+    <div>
+      <div class="toolbar">
+        <input placeholder="Search tags..." value=${filter} onInput=${(e) => setFilter(e.target.value)} />
+        <button class="btn btn-primary" onClick=${() => setEditing("new")}>+ New Tag</button>
+        <button class="btn btn-ghost" onClick=${load}>Refresh</button>
+      </div>
+      ${items.length === 0 ? html`
+        <div class="empty">${loading ? "Loading..." : "No tags yet. Create one!"}</div>
+      ` : html`
+        <table>
+          <thead>
+            <tr>
+              <th>Color</th>
+              <th>Name</th>
+              <th>Slug</th>
+              <th>Description</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map(t => html`
+              <tr key=${t.slug}>
+                <td><span style="display:inline-block;width:16px;height:16px;border-radius:50%;background:${t.color || '#666'}" /></td>
+                <td>${t.name}</td>
+                <td class="mono">${t.slug}</td>
+                <td style="color:var(--text-muted)">${t.description || "-"}</td>
+                <td>
+                  <button class="btn btn-ghost btn-sm" onClick=${() => setEditing(t)}>Edit</button>
+                  <button class="btn btn-danger btn-sm" style="margin-left:4px" onClick=${() => handleDelete(t.slug)}>Delete</button>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      `}
+      ${editing !== null && html`
+        <${TagForm}
+          initial=${editing === "new" ? null : editing}
+          onSave=${handleSave}
+          onCancel=${() => setEditing(null)}
+        />
+      `}
+    </div>
+  `;
+}

--- a/sample-apps/blog-system/webui/components/users.js
+++ b/sample-apps/blog-system/webui/components/users.js
@@ -1,0 +1,144 @@
+import { h } from "https://esm.sh/preact@10.25.4";
+import { useState, useEffect } from "https://esm.sh/preact@10.25.4/hooks";
+import htm from "https://esm.sh/htm@3.1.1";
+import { users } from "../api.js";
+
+const html = htm.bind(h);
+
+function UserForm({ initial, onSave, onCancel }) {
+  const [form, setForm] = useState(initial || {
+    username: "", email: "", name: "", bio: "", website: "", password: ""
+  });
+  const set = (k, v) => setForm({ ...form, [k]: v });
+
+  return html`
+    <div class="modal-overlay" onClick=${(e) => e.target === e.currentTarget && onCancel()}>
+      <div class="modal">
+        <h2>${initial ? "Edit User" : "New User"}</h2>
+        <div class="form-group">
+          <label>Username</label>
+          <input value=${form.username} onInput=${(e) => set("username", e.target.value)} placeholder="3-30 chars, alphanumeric + _" />
+        </div>
+        <div class="form-group">
+          <label>Email</label>
+          <input type="email" value=${form.email} onInput=${(e) => set("email", e.target.value)} placeholder="user@example.com" />
+        </div>
+        <div class="form-group">
+          <label>Name</label>
+          <input value=${form.name} onInput=${(e) => set("name", e.target.value)} placeholder="Display name (2-50 chars)" />
+        </div>
+        ${!initial && html`
+          <div class="form-group">
+            <label>Password</label>
+            <input type="password" value=${form.password || ""} onInput=${(e) => set("password", e.target.value)} placeholder="Password" />
+          </div>
+        `}
+        <div class="form-group">
+          <label>Bio</label>
+          <textarea rows="3" value=${form.bio || ""} onInput=${(e) => set("bio", e.target.value)} placeholder="Short bio (max 500 chars)" />
+        </div>
+        <div class="form-group">
+          <label>Website</label>
+          <input value=${form.website || ""} onInput=${(e) => set("website", e.target.value)} placeholder="https://example.com" />
+        </div>
+        <div class="modal-actions">
+          <button class="btn btn-ghost" onClick=${onCancel}>Cancel</button>
+          <button class="btn btn-primary" onClick=${() => onSave(form)}>
+            ${initial ? "Update" : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export function UsersPanel({ notify }) {
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [editing, setEditing] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const res = await users.list(filter);
+      setItems(res?.results || []);
+    } catch (e) {
+      notify(e.message, "error");
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => { load(); }, [filter]);
+
+  const handleSave = async (form) => {
+    try {
+      if (editing === "new") {
+        await users.create(form);
+        notify("User created");
+      } else {
+        await users.patch(editing.uuid, form);
+        notify("User updated");
+      }
+      setEditing(null);
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  const handleDelete = async (uuid) => {
+    if (!confirm("Delete this user?")) return;
+    try {
+      await users.delete(uuid);
+      notify("User deleted");
+      load();
+    } catch (e) {
+      notify(e.message, "error");
+    }
+  };
+
+  return html`
+    <div>
+      <div class="toolbar">
+        <input placeholder="Search users..." value=${filter} onInput=${(e) => setFilter(e.target.value)} />
+        <button class="btn btn-primary" onClick=${() => setEditing("new")}>+ New User</button>
+        <button class="btn btn-ghost" onClick=${load}>Refresh</button>
+      </div>
+      ${items.length === 0 ? html`
+        <div class="empty">${loading ? "Loading..." : "No users yet. Create one!"}</div>
+      ` : html`
+        <table>
+          <thead>
+            <tr>
+              <th>Username</th>
+              <th>Name</th>
+              <th>Email</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${items.map(u => html`
+              <tr key=${u.uuid}>
+                <td class="mono">${u.username}</td>
+                <td>${u.name}</td>
+                <td>${u.email}</td>
+                <td>
+                  <button class="btn btn-ghost btn-sm" onClick=${() => setEditing(u)}>Edit</button>
+                  <button class="btn btn-danger btn-sm" style="margin-left:4px" onClick=${() => handleDelete(u.uuid)}>Delete</button>
+                </td>
+              </tr>
+            `)}
+          </tbody>
+        </table>
+      `}
+      ${editing !== null && html`
+        <${UserForm}
+          initial=${editing === "new" ? null : editing}
+          onSave=${handleSave}
+          onCancel=${() => setEditing(null)}
+        />
+      `}
+    </div>
+  `;
+}

--- a/sample-apps/blog-system/webui/index.html
+++ b/sample-apps/blog-system/webui/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Blog Admin</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/sample-apps/blog-system/webui/styles.css
+++ b/sample-apps/blog-system/webui/styles.css
@@ -1,0 +1,155 @@
+:root {
+  --bg-primary: #0f1117;
+  --bg-secondary: #1a1d27;
+  --bg-tertiary: #252830;
+  --border: #2e3140;
+  --text-primary: #e4e6eb;
+  --text-muted: #8b8fa3;
+  --accent: #4f8ff7;
+  --accent-hover: #3a7ae0;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
+  --success: #22c55e;
+  --warning: #eab308;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.5;
+}
+
+.app { display: flex; flex-direction: column; height: 100vh; }
+
+/* Header */
+.header {
+  display: flex; align-items: center; gap: 1rem;
+  padding: 0.75rem 1.5rem;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
+}
+.header h1 { font-size: 1.125rem; font-weight: 600; }
+.header h1 span { color: var(--accent); }
+.nav { display: flex; gap: 0.25rem; margin-left: 2rem; }
+.nav button {
+  padding: 0.375rem 0.75rem; border: none; border-radius: 4px;
+  background: transparent; color: var(--text-muted);
+  cursor: pointer; font-size: 0.875rem;
+}
+.nav button:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.nav button.active { background: var(--accent); color: white; }
+
+/* Content */
+.content { flex: 1; overflow: auto; padding: 1.5rem; }
+
+/* Toolbar */
+.toolbar {
+  display: flex; gap: 0.75rem; align-items: center;
+  margin-bottom: 1rem;
+}
+.toolbar input {
+  flex: 1; max-width: 400px;
+  padding: 0.5rem 0.75rem;
+  background: var(--bg-tertiary); border: 1px solid var(--border);
+  color: var(--text-primary); border-radius: 4px; font-size: 0.875rem;
+}
+.toolbar input:focus { outline: none; border-color: var(--accent); }
+
+/* Buttons */
+.btn {
+  padding: 0.5rem 1rem; border: none; border-radius: 4px;
+  cursor: pointer; font-size: 0.875rem; font-weight: 500;
+  transition: background 0.15s;
+}
+.btn-primary { background: var(--accent); color: white; }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-danger { background: var(--danger); color: white; }
+.btn-danger:hover { background: var(--danger-hover); }
+.btn-ghost {
+  background: transparent; color: var(--text-muted);
+  border: 1px solid var(--border);
+}
+.btn-ghost:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.btn-sm { padding: 0.25rem 0.5rem; font-size: 0.8125rem; }
+
+/* Table */
+table { width: 100%; border-collapse: collapse; }
+thead { background: var(--bg-secondary); }
+th {
+  text-align: left; padding: 0.625rem 0.75rem;
+  font-size: 0.75rem; text-transform: uppercase;
+  color: var(--text-muted); font-weight: 600;
+  border-bottom: 1px solid var(--border);
+}
+td {
+  padding: 0.625rem 0.75rem; font-size: 0.875rem;
+  border-bottom: 1px solid var(--border);
+}
+tr:hover { background: var(--bg-secondary); }
+.mono { font-family: "JetBrains Mono", "Fira Code", monospace; }
+
+/* Badge */
+.badge {
+  display: inline-block; padding: 0.125rem 0.5rem;
+  border-radius: 9999px; font-size: 0.75rem; font-weight: 500;
+}
+.badge-green { background: rgba(34,197,94,0.15); color: var(--success); }
+.badge-yellow { background: rgba(234,179,8,0.15); color: var(--warning); }
+.badge-red { background: rgba(239,68,68,0.15); color: var(--danger); }
+.badge-blue { background: rgba(79,143,247,0.15); color: var(--accent); }
+
+/* Modal */
+.modal-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.6); display: flex;
+  align-items: center; justify-content: center;
+  z-index: 100;
+}
+.modal {
+  background: var(--bg-secondary); border: 1px solid var(--border);
+  border-radius: 8px; padding: 1.5rem;
+  width: 100%; max-width: 600px; max-height: 80vh;
+  overflow-y: auto;
+}
+.modal h2 { margin-bottom: 1rem; font-size: 1.125rem; }
+.modal-actions {
+  display: flex; gap: 0.5rem; justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+/* Form */
+.form-group { margin-bottom: 1rem; }
+.form-group label {
+  display: block; margin-bottom: 0.25rem;
+  font-size: 0.8125rem; color: var(--text-muted); font-weight: 500;
+}
+.form-group input, .form-group textarea, .form-group select {
+  width: 100%; padding: 0.5rem 0.75rem;
+  background: var(--bg-tertiary); border: 1px solid var(--border);
+  color: var(--text-primary); border-radius: 4px; font-size: 0.875rem;
+  font-family: inherit;
+}
+.form-group input:focus, .form-group textarea:focus, .form-group select:focus {
+  outline: none; border-color: var(--accent);
+}
+.form-group textarea { min-height: 100px; resize: vertical; }
+
+/* Empty state */
+.empty {
+  text-align: center; padding: 3rem;
+  color: var(--text-muted);
+}
+
+/* Toast */
+.toast {
+  position: fixed; bottom: 1.5rem; right: 1.5rem;
+  padding: 0.75rem 1.25rem; border-radius: 6px;
+  font-size: 0.875rem; z-index: 200;
+  animation: slideIn 0.2s ease-out;
+}
+.toast-success { background: var(--success); color: white; }
+.toast-error { background: var(--danger); color: white; }
+@keyframes slideIn { from { transform: translateY(1rem); opacity: 0; } to { transform: translateY(0); opacity: 1; } }


### PR DESCRIPTION
## Summary

### Blog Admin Web UI
- Preact + htm from CDN (no build step), dark theme matching debug UI
- CRUD panels for Posts, Users, Tags, Comments
- Served at `/admin` via ResourceService

### HTTP Pipeline
- `WebContext.flushHeaders()` writes stored headers to ServerResponse via `writeHead()`
- `WebContext.end()` flushes headers + buffered body, skips if stream already ended (pipeline)
- HttpServer handler simplified to: create context → Router.execute → ctx.end()
- ERR_STREAM_PREMATURE_CLOSE handled for pipeline streams
- Session save made resilient to missing SessionManager

### Known Issue
- Static file streaming via `pipeline()` works in isolation but the `Webda.Request` core event listener (from DebugService/Prometheus) interferes with the response stream in the full app context. API responses work correctly. Needs separate investigation.

## Test Plan
- [ ] `GET /version` returns app name
- [ ] `PUT /posts` returns query results  
- [ ] `GET /nonexistent` returns 404
- [ ] Core: 407 tests pass
- [ ] Open `/admin` in browser (once static file streaming is fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)