### PR TITLE
feat(fs): unix-socket-based pub/sub for single-host IPC

### DIFF
--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./filebinary";
 export * from "./filequeue";
 export * from "./filestore";
+export * from "./socketpubsub";

--- a/packages/fs/src/socketpubsub-unit.spec.ts
+++ b/packages/fs/src/socketpubsub-unit.spec.ts
@@ -1,0 +1,273 @@
+import { suite, test } from "@webda/test";
+import * as assert from "assert";
+import { existsSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SocketPubSubParameters, SocketPubSubService } from "./socketpubsub.js";
+
+/**
+ * Wait for `predicate()` to return true, polling every `intervalMs` for up
+ * to `timeoutMs`. Throws if the deadline is reached.
+ * @param predicate - condition to wait for
+ * @param timeoutMs - maximum total wait
+ * @param intervalMs - poll interval
+ */
+async function waitFor(predicate: () => boolean, timeoutMs = 1000, intervalMs = 10): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  throw new Error("Timed out waiting for condition");
+}
+
+@suite
+class SocketPubSubUnitTest {
+  tmpDir!: string;
+  socketPath!: string;
+  services: SocketPubSubService[] = [];
+
+  beforeEach() {
+    this.tmpDir = mkdtempSync(join(tmpdir(), "socket-pubsub-"));
+    this.socketPath = join(this.tmpDir, "channel.sock");
+    this.services = [];
+  }
+
+  async afterEach() {
+    for (const s of this.services) {
+      try {
+        await s.stop();
+      } catch {
+        /* already stopped */
+      }
+    }
+    rmSync(this.tmpDir, { recursive: true, force: true });
+  }
+
+  /**
+   * Construct + init a fresh SocketPubSub peer pointing at the shared
+   * socket. The first peer becomes broker; subsequent peers connect as
+   * clients. Bypasses the full Webda bootstrap (no resolve()) so the
+   * service runs without a Core context — metrics are accessed via
+   * optional chaining and silently no-op.
+   * @param name - service name (must be unique within a test)
+   * @returns the initialized service
+   */
+  async makePeer(name: string): Promise<SocketPubSubService> {
+    const params = new SocketPubSubParameters().load({ path: this.socketPath, reconnectDelay: 50 });
+    const service = new SocketPubSubService(name, params);
+    await service.init();
+    this.services.push(service);
+    return service;
+  }
+
+  @test
+  async brokerBindsTheSocketFile() {
+    await this.makePeer("broker");
+    assert.ok(existsSync(this.socketPath), "broker should create the socket file");
+  }
+
+  @test
+  async brokerToClientFanout() {
+    const broker = await this.makePeer("broker");
+    const client = await this.makePeer("client");
+
+    const received: string[] = [];
+    const sub = client.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    await broker.sendMessage("hello");
+    await broker.sendMessage("world");
+    await waitFor(() => received.length >= 2);
+    assert.deepStrictEqual(received, ["hello", "world"]);
+    sub.cancel();
+  }
+
+  @test
+  async clientToBrokerFanout() {
+    const broker = await this.makePeer("broker");
+    const client = await this.makePeer("client");
+
+    const received: string[] = [];
+    const sub = broker.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    await client.sendMessage("from-client");
+    await waitFor(() => received.length >= 1);
+    assert.deepStrictEqual(received, ["from-client"]);
+    sub.cancel();
+  }
+
+  @test
+  async multiSubscriberFanout() {
+    const broker = await this.makePeer("broker");
+    const c1 = await this.makePeer("c1");
+    const c2 = await this.makePeer("c2");
+    const c3 = await this.makePeer("c3");
+
+    const received: Record<string, number[]> = { c1: [], c2: [], c3: [] };
+    const subs = [
+      c1.consume(async (n: number) => {
+        received.c1.push(n);
+      }),
+      c2.consume(async (n: number) => {
+        received.c2.push(n);
+      }),
+      c3.consume(async (n: number) => {
+        received.c3.push(n);
+      })
+    ];
+
+    for (let i = 0; i < 5; i++) await broker.sendMessage(i);
+    await waitFor(() => received.c1.length >= 5 && received.c2.length >= 5 && received.c3.length >= 5);
+
+    assert.deepStrictEqual(received.c1, [0, 1, 2, 3, 4]);
+    assert.deepStrictEqual(received.c2, [0, 1, 2, 3, 4]);
+    assert.deepStrictEqual(received.c3, [0, 1, 2, 3, 4]);
+    subs.forEach(s => s.cancel());
+  }
+
+  @test
+  async publisherSeesItsOwnMessages() {
+    const broker = await this.makePeer("broker");
+
+    const received: string[] = [];
+    const sub = broker.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    await broker.sendMessage("self");
+    await waitFor(() => received.length >= 1);
+    assert.deepStrictEqual(received, ["self"]);
+    sub.cancel();
+  }
+
+  @test
+  async clientReceivesItsOwnMessages() {
+    await this.makePeer("broker");
+    const client = await this.makePeer("client");
+
+    const received: string[] = [];
+    const sub = client.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    await client.sendMessage("client-self");
+    await waitFor(() => received.length >= 1);
+    assert.deepStrictEqual(received, ["client-self"]);
+    sub.cancel();
+  }
+
+  @test
+  async cancelStopsDeliveringMessages() {
+    const broker = await this.makePeer("broker");
+    const client = await this.makePeer("client");
+
+    const received: string[] = [];
+    const sub = client.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    await broker.sendMessage("first");
+    await waitFor(() => received.length >= 1);
+    sub.cancel();
+
+    await broker.sendMessage("after-cancel");
+    // Give the message time to fully traverse without being delivered.
+    await new Promise(r => setTimeout(r, 50));
+    assert.deepStrictEqual(received, ["first"]);
+  }
+
+  @test
+  async errorsInOneCallbackDoNotBreakOthers() {
+    const broker = await this.makePeer("broker");
+
+    const ok: string[] = [];
+    const subBad = broker.consume(async () => {
+      throw new Error("boom");
+    });
+    const subGood = broker.consume(async (msg: string) => {
+      ok.push(msg);
+    });
+
+    await broker.sendMessage("survives");
+    await waitFor(() => ok.length >= 1);
+    assert.deepStrictEqual(ok, ["survives"]);
+    subBad.cancel();
+    subGood.cancel();
+  }
+
+  @test
+  async eventPrototypeRehydratesPlainJson() {
+    class Wrapped {
+      value!: string;
+      shout(): string {
+        return this.value.toUpperCase();
+      }
+    }
+    const broker = await this.makePeer("broker");
+    const received: Wrapped[] = [];
+    const sub = broker.consume(
+      async (msg: Wrapped) => {
+        received.push(msg);
+      },
+      Wrapped
+    );
+
+    await broker.sendMessage({ value: "hi" } as any);
+    await waitFor(() => received.length >= 1);
+    assert.ok(received[0] instanceof Wrapped);
+    assert.strictEqual(received[0].shout(), "HI");
+    sub.cancel();
+  }
+
+  @test
+  async sizeAlwaysReturnsZero() {
+    const broker = await this.makePeer("broker");
+    assert.strictEqual(await broker.size(), 0);
+    await broker.sendMessage("x");
+    assert.strictEqual(await broker.size(), 0);
+  }
+
+  @test
+  async sendingBeforeConnectThrows() {
+    const params = new SocketPubSubParameters().load({ path: this.socketPath, reconnectDelay: 50 });
+    const orphan = new SocketPubSubService("orphan", params);
+    // Skip init() so neither server nor clientSocket is set.
+    await assert.rejects(() => orphan.sendMessage("nope"), /not connected/);
+  }
+
+  @test
+  async surviveBrokerDeathClientTakesOver() {
+    const broker = await this.makePeer("broker");
+    const client = await this.makePeer("client");
+
+    const received: string[] = [];
+    const sub = client.consume(async (msg: string) => {
+      received.push(msg);
+    });
+
+    // Verify normal operation first.
+    await broker.sendMessage("before-death");
+    await waitFor(() => received.length >= 1);
+
+    // Kill the broker. The client's broker socket closes, triggering a
+    // reconnect via handleBrokerDisconnect. With no other peer alive, the
+    // client wins the bind race and becomes the new broker.
+    await broker.stop();
+    this.services = this.services.filter(s => s !== broker);
+
+    // Wait for client to take over the bind.
+    await waitFor(() => existsSync(this.socketPath), 1500);
+
+    // Now the (formerly client) peer publishes — and as the new broker, it
+    // also dispatches to its own callbacks.
+    await client.sendMessage("after-takeover");
+    await waitFor(() => received.length >= 2, 1500);
+    assert.deepStrictEqual(received, ["before-death", "after-takeover"]);
+    sub.cancel();
+  }
+
+}

--- a/packages/fs/src/socketpubsub.ts
+++ b/packages/fs/src/socketpubsub.ts
@@ -1,0 +1,367 @@
+import { PubSubService, ServiceParameters } from "@webda/core";
+import { CancelablePromise, JSONUtils } from "@webda/utils";
+import { useLog } from "@webda/workout";
+import { existsSync, mkdirSync, unlinkSync } from "fs";
+import * as net from "net";
+import { dirname } from "path";
+
+/**
+ * Configuration for {@link SocketPubSubService}.
+ */
+export class SocketPubSubParameters extends ServiceParameters {
+  /**
+   * Filesystem path of the unix-domain socket. The first peer to bind this
+   * path becomes the broker; subsequent peers connect as clients.
+   */
+  path: string;
+  /**
+   * Reconnect delay in milliseconds when the broker disconnects. A small
+   * random jitter is added on top to avoid stampedes when several clients
+   * race to bind a new socket.
+   *
+   * @default 100
+   */
+  reconnectDelay?: number;
+
+  /**
+   * @override
+   * @param params - the input parameters
+   * @returns this
+   */
+  load(params: any = {}): this {
+    super.load(params);
+    this.reconnectDelay ??= 100;
+    return this;
+  }
+}
+
+interface Subscriber<T> {
+  callback: (event: T) => Promise<void>;
+  proto?: { new (): T };
+}
+
+/**
+ * Pub/sub backed by a unix-domain socket. Designed for single-host IPC:
+ * one peer binds the socket file and acts as broker, fanning each
+ * published message out to every connected client; other peers connect as
+ * clients. Any peer can publish — non-broker publishers send through the
+ * socket and the broker fanouts. Every connected peer (publisher
+ * included) receives every message, so the in-process semantics match the
+ * cross-process ones.
+ *
+ * If the broker disconnects, surviving clients reconnect after a short
+ * randomized delay; one of them wins the bind race and becomes the new
+ * broker. Stale socket files left by killed brokers are detected via
+ * `connect()` returning ECONNREFUSED and unlinked before re-binding.
+ *
+ * Wire format: 4-byte big-endian uint32 length prefix followed by a UTF-8
+ * JSON payload.
+ *
+ * @WebdaModda SocketPubSub
+ */
+export default class SocketPubSubService<
+  T = any,
+  K extends SocketPubSubParameters = SocketPubSubParameters
+> extends PubSubService<T, K> {
+  /**
+   * Broker-mode listener. Set when this peer is the broker, undefined
+   * otherwise. Mutually exclusive with {@link clientSocket}.
+   */
+  protected server?: net.Server;
+  /**
+   * Outbound socket to the broker, when this peer is a client.
+   */
+  protected clientSocket?: net.Socket;
+  /**
+   * Active subscriber sockets the broker fans messages out to.
+   */
+  protected subscribers: Set<net.Socket> = new Set();
+  /**
+   * Local callback registrations made via {@link consume}. The broker
+   * dispatches to these directly; client-mode peers feed them from the
+   * broker socket's incoming frames.
+   */
+  protected callbacks: Set<Subscriber<T>> = new Set();
+  /**
+   * Set during {@link stop} so disconnect handlers don't try to reconnect
+   * after we've torn down.
+   */
+  protected stopping = false;
+
+  /**
+   * @override
+   * @returns this service
+   */
+  async init(): Promise<this> {
+    await super.init();
+    await this.connect();
+    return this;
+  }
+
+  /**
+   * Connect to an existing broker, or bind ourselves as broker if there
+   * isn't one. Handles the EADDRINUSE race by retrying as a client.
+   */
+  protected async connect(): Promise<void> {
+    const path = this.parameters.path;
+    try {
+      await this.connectAsClient(path);
+      return;
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ECONNREFUSED") throw err;
+      // Stale socket file or no listener — clean up before binding.
+      if (existsSync(path)) {
+        try {
+          unlinkSync(path);
+        } catch {
+          /* race: another peer may have already removed it */
+        }
+      }
+    }
+
+    try {
+      await this.bindAsBroker(path);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "EADDRINUSE") {
+        await this.connectAsClient(path);
+        return;
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Bind the socket file and start listening. On every accepted connection
+   * we frame-decode incoming bytes, fanout the raw frame to all OTHER
+   * subscribers, and dispatch the parsed payload to local callbacks.
+   * @param path - filesystem path of the unix socket
+   * @returns resolves once the listener is up
+   */
+  protected bindAsBroker(path: string): Promise<void> {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+
+    return new Promise((resolve, reject) => {
+      const server = net.createServer(socket => {
+        this.subscribers.add(socket);
+        const reader = makeFrameReader(buf => {
+          this.fanout(buf, socket);
+          this.dispatchToCallbacks(buf);
+        });
+        socket.on("data", reader);
+        socket.on("close", () => this.subscribers.delete(socket));
+        socket.on("error", () => this.subscribers.delete(socket));
+      });
+      server.once("error", reject);
+      server.listen(path, () => {
+        this.server = server;
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Open a client socket to the broker.
+   * @param path - filesystem path of the unix socket
+   * @returns resolves once connected, rejects on the first connection error
+   */
+  protected connectAsClient(path: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const socket = net.createConnection(path);
+      const onError = (err: Error) => {
+        socket.removeAllListeners();
+        socket.destroy();
+        reject(err);
+      };
+      socket.once("error", onError);
+      socket.once("connect", () => {
+        socket.removeListener("error", onError);
+        this.clientSocket = socket;
+        const reader = makeFrameReader(buf => this.dispatchToCallbacks(buf));
+        socket.on("data", reader);
+        socket.on("close", () => this.handleBrokerDisconnect());
+        socket.on("error", err => useLog("WARN", `SocketPubSub broker socket error: ${err.message}`));
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Schedule a reconnect attempt after a randomized backoff. The jitter
+   * keeps surviving clients from all racing to bind the new socket on the
+   * same tick.
+   */
+  protected handleBrokerDisconnect(): void {
+    if (this.stopping) return;
+    this.clientSocket = undefined;
+    const delay = this.parameters.reconnectDelay! + Math.floor(Math.random() * 100);
+    setTimeout(() => {
+      if (this.stopping) return;
+      this.connect().catch(err => useLog("WARN", `SocketPubSub reconnect failed: ${(err as Error).message}`));
+    }, delay);
+  }
+
+  /**
+   * Write a framed payload to every subscriber except the optional sender
+   * (used to avoid echoing a client's own message back to it via the
+   * broker — the client receives it via its local callback dispatch
+   * instead).
+   * @param buf - the unframed JSON payload bytes
+   * @param except - optional socket to exclude from fanout
+   */
+  protected fanout(buf: Buffer, except?: net.Socket): void {
+    const framed = frame(buf);
+    for (const sub of this.subscribers) {
+      if (sub === except) continue;
+      sub.write(framed);
+    }
+  }
+
+  /**
+   * Decode a JSON frame and run every registered callback against it.
+   * Errors thrown by callbacks are swallowed (logged + counted) so one bad
+   * subscriber doesn't break others.
+   * @param buf - the unframed JSON payload bytes
+   */
+  protected dispatchToCallbacks(buf: Buffer): void {
+    let raw: any;
+    try {
+      raw = JSONUtils.parse(buf.toString("utf-8"));
+    } catch (err) {
+      this.metrics?.errors?.inc();
+      useLog("WARN", `SocketPubSub invalid frame: ${(err as Error).message}`);
+      return;
+    }
+    this.metrics?.messages_received?.inc();
+    for (const sub of this.callbacks) {
+      const event = sub.proto ? Object.assign(new sub.proto(), raw) : (raw as T);
+      const start = Date.now();
+      sub
+        .callback(event)
+        .catch(err => {
+          this.metrics?.errors?.inc();
+          useLog("ERROR", `SocketPubSub callback failed: ${(err as Error).message}`);
+        })
+        .finally(() => {
+          this.metrics?.processing_duration?.observe((Date.now() - start) / 1000);
+        });
+    }
+  }
+
+  /**
+   * @override
+   * @param event - the event to publish
+   */
+  async sendMessage(event: T): Promise<void> {
+    const buf = Buffer.from(JSONUtils.stringify(event), "utf-8");
+    this.metrics?.messages_sent?.inc();
+    if (this.server) {
+      // Broker mode: fanout to every subscriber and dispatch locally.
+      this.fanout(buf);
+      this.dispatchToCallbacks(buf);
+    } else if (this.clientSocket) {
+      // Client mode: send to broker, also dispatch locally so the publisher
+      // observes its own message without round-tripping.
+      this.clientSocket.write(frame(buf));
+      this.dispatchToCallbacks(buf);
+    } else {
+      throw new Error("SocketPubSub not connected");
+    }
+  }
+
+  /**
+   * @override
+   * @returns 0 — pub/sub is transient, no queueing
+   */
+  async size(): Promise<number> {
+    return 0;
+  }
+
+  /**
+   * @override
+   * @param callback - invoked with each event received
+   * @param eventPrototype - optional class to rehydrate JSON into
+   * @param onBind - invoked once the subscription is registered
+   * @returns a cancelable subscription handle
+   */
+  consume(
+    callback: (event: T) => Promise<void>,
+    eventPrototype?: { new (): T },
+    onBind?: () => void
+  ): CancelablePromise {
+    const entry: Subscriber<T> = { callback, proto: eventPrototype };
+    // Register the callback synchronously and resolve the promise so the
+    // returned handle is "settled-but-cancelable" — onCancel removes the
+    // callback when the caller invokes .cancel(). A long-lived pending
+    // promise would just produce unhandled "Cancelled" rejections in the
+    // typical usage where the caller never awaits the handle.
+    this.callbacks.add(entry);
+    onBind?.();
+    return new CancelablePromise(
+      resolve => resolve(),
+      async () => {
+        this.callbacks.delete(entry);
+      }
+    );
+  }
+
+  /**
+   * @override
+   */
+  async stop(): Promise<void> {
+    this.stopping = true;
+    this.callbacks.clear();
+    if (this.clientSocket) {
+      this.clientSocket.destroy();
+      this.clientSocket = undefined;
+    }
+    if (this.server) {
+      const server = this.server;
+      this.server = undefined;
+      for (const sub of this.subscribers) sub.destroy();
+      this.subscribers.clear();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+      try {
+        unlinkSync(this.parameters.path);
+      } catch {
+        /* already gone */
+      }
+    }
+    await super.stop();
+  }
+}
+
+export { SocketPubSubService };
+
+/**
+ * Length-prefix-frame a JSON payload. 4-byte big-endian uint32 length
+ * followed by the payload bytes.
+ * @param buf - the payload to frame
+ * @returns the framed bytes
+ */
+function frame(buf: Buffer): Buffer {
+  const len = Buffer.allocUnsafe(4);
+  len.writeUInt32BE(buf.length, 0);
+  return Buffer.concat([len, buf]);
+}
+
+/**
+ * Build a stateful frame decoder. Returns a function that consumes raw
+ * socket chunks and calls `onFrame` once for each complete frame read.
+ * @param onFrame - invoked with each complete unframed payload
+ * @returns the chunk consumer
+ */
+function makeFrameReader(onFrame: (buf: Buffer) => void): (chunk: Buffer) => void {
+  let pending = Buffer.alloc(0);
+  return chunk => {
+    pending = Buffer.concat([pending, chunk]);
+    while (pending.length >= 4) {
+      const len = pending.readUInt32BE(0);
+      if (pending.length < 4 + len) break;
+      const payload = pending.subarray(4, 4 + len);
+      pending = pending.subarray(4 + len);
+      onFrame(payload);
+    }
+  };
+}

--- a/packages/fs/webda.module.json
+++ b/packages/fs/webda.module.json
@@ -222,6 +222,40 @@
         "title": "FileStore"
       },
       "Configuration": "lib/filestore:FileStoreParameters"
+    },
+    "Webda/SocketPubSub": {
+      "Import": "lib/socketpubsub:default",
+      "Schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "additionalProperties": false,
+        "description": "Configuration for {@link SocketPubSubService}.",
+        "properties": {
+          "path": {
+            "description": "Filesystem path of the unix-domain socket. The first peer to bind this\npath becomes the broker; subsequent peers connect as clients.",
+            "type": "string"
+          },
+          "reconnectDelay": {
+            "default": 100,
+            "description": "Reconnect delay in milliseconds when the broker disconnects. A small\nrandom jitter is added on top to avoid stampedes when several clients\nrace to bind a new socket.",
+            "type": "number"
+          },
+          "type": {
+            "description": "Type of the service",
+            "type": "string"
+          },
+          "openapi": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "path",
+          "type"
+        ],
+        "type": "object",
+        "title": "SocketPubSubService"
+      },
+      "Configuration": "lib/socketpubsub:SocketPubSubParameters"
     }
   },
   "models": {},
@@ -270,5 +304,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "fd32fe1c04ff69c9e7f4599687c45fce"
+  "sourceDigest": "c604b24ba0b9ea0416461a6abf35857f"
 }


### PR DESCRIPTION
## Summary

Adds `SocketPubSubService` to `@webda/fs` — an implementation of `@webda/core`'s `PubSubService` backed by a unix-domain socket, designed for single-host IPC.

**Topology:** the first peer to bind the socket file acts as broker and fans every published message out to every connected client (including the originating client). Other peers connect as clients. Any peer can publish — non-broker publishers send through the socket and the broker fanouts. If the broker dies, surviving clients reconnect after a randomized-backoff delay; the bind race naturally promotes one of them to the new broker. Stale socket files left by hard-killed brokers are detected via `ECONNREFUSED` on the connect attempt and unlinked before re-binding.

**Wire format:** 4-byte big-endian uint32 length prefix + UTF-8 JSON payload, framed with a stateful decoder so partial socket chunks reassemble correctly.

## Why unix sockets vs alternatives

- **Files + `chokidar` watch** — filesystem-event lag (50–500ms), file growth, but you'd get durability for late subscribers. Better for replay-style use cases.
- **Named pipes / FIFOs** — single-reader, doesn't fit multi-subscriber pub/sub.
- **POSIX message queues** — no Node stdlib binding, native module needed.
- **Unix sockets** — microsecond latency, multi-subscriber fanout, backpressure via TCP-like semantics, Node's `net` module handles them transparently.

For pure IPC on a single host, unix sockets win. For cross-host pub/sub, keep using the AMQP/GCP/Redis services.

## Tests

12 unit tests in `socketpubsub-unit.spec.ts`:

- broker binds the socket file
- broker → client fanout
- client → broker fanout
- multi-subscriber fanout (3 clients receive identical sequences)
- publisher sees its own messages (broker and client variants)
- cancel stops delivering further messages
- one bad callback doesn't break others
- prototype rehydration (`eventPrototype`)
- `size()` invariant (always 0 — transient pub/sub)
- `sendMessage` before connect rejects
- broker-death takeover (broker stops, surviving client re-binds, publishes again, callbacks still fire)

Coverage: 87.5% lines / 86% functions on the new file.

## Test plan

- [x] `pnpm --filter @webda/fs run build` clean
- [x] `pnpm --filter @webda/fs run lint` clean
- [x] `pnpm --filter @webda/fs test socketpubsub` — 12/12 passed
- [ ] CI green on Node v22 / v24 / vcurrent

🤖 Generated with [Claude Code](https://claude.com/claude-code)