### PR TITLE
feat(core): flat models[] config + internal field migration (PR 1 of 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ package-lock.json
 .vite-custom
 docs/superpowers
 pnpm-lock.yaml
+.worktrees

--- a/packages/core/src/models/coremodel.spec.ts
+++ b/packages/core/src/models/coremodel.spec.ts
@@ -290,7 +290,7 @@ class CoreModelTest extends WebdaApplicationTest {
 
   @test async ref() {
     this.webda.getApplication().addModel("webdatest", TestMask);
-    await this.addService<MemoryStore>(MemoryStore, { forceModel: false, model: "webdatest" }, "MemoryUsers");
+    await this.addService<MemoryStore>(MemoryStore, { forceModel: false, models: ["webdatest"] }, "MemoryUsers");
     useConfiguration().parameters!["defaultStore"] = "MemoryUsers";
     assert.strictEqual(await TestMask.ref("unit1").exists(), false);
     console.log("LOAD OR CREATE");

--- a/packages/core/src/services/oauth.spec.ts
+++ b/packages/core/src/services/oauth.spec.ts
@@ -54,11 +54,11 @@ class OAuthServiceTest extends WebdaApplicationTest {
         },
         Idents: {
           type: "MemoryStore",
-          model: "Webda/Ident"
+          models: ["Webda/Ident"]
         },
         Users: {
           type: "MemoryStore",
-          model: "Webda/User"
+          models: ["Webda/User"]
         }
       }
     };

--- a/packages/core/src/stores/memory.spec.ts
+++ b/packages/core/src/stores/memory.spec.ts
@@ -265,6 +265,23 @@ class AdditionalMemoryTest extends WebdaApplicationTest {
     });
   }
 
+  @test
+  async populatesModelsArrayAndMetadatas() {
+    const store = new MemoryStore("multi", { models: ["WebdaDemo/Project", "WebdaDemo/SubProject"] });
+    store.resolve();
+    assert.strictEqual((store as any)._models.length, 2);
+    assert.strictEqual((store as any)._modelMetadatas.size, 2);
+    assert.strictEqual((store as any)._modelsHierarchy["WebdaDemo/Project"], 0);
+    assert.strictEqual((store as any)._modelsHierarchy["WebdaDemo/SubProject"], 0);
+  }
+
+  @test
+  async getModelReturnsFirstForBackCompat() {
+    const store = new MemoryStore("first-model", { models: ["WebdaDemo/Project"] });
+    store.resolve();
+    assert.strictEqual(store.getModel()?.name, "Project");
+  }
+
   getTestConfiguration() {
     return "../../sample-app/webda.config.jsonc";
   }

--- a/packages/core/src/stores/memory.spec.ts
+++ b/packages/core/src/stores/memory.spec.ts
@@ -265,23 +265,6 @@ class AdditionalMemoryTest extends WebdaApplicationTest {
     });
   }
 
-  @test
-  async populatesModelsArrayAndMetadatas() {
-    const store = new MemoryStore("multi", { models: ["WebdaDemo/Project", "WebdaDemo/SubProject"] });
-    store.resolve();
-    assert.strictEqual((store as any)._models.length, 2);
-    assert.strictEqual((store as any)._modelMetadatas.size, 2);
-    assert.strictEqual((store as any)._modelsHierarchy["WebdaDemo/Project"], 0);
-    assert.strictEqual((store as any)._modelsHierarchy["WebdaDemo/SubProject"], 0);
-  }
-
-  @test
-  async getModelReturnsFirstForBackCompat() {
-    const store = new MemoryStore("first-model", { models: ["WebdaDemo/Project"] });
-    store.resolve();
-    assert.strictEqual(store.getModel()?.name, "Project");
-  }
-
   getTestConfiguration() {
     return "../../sample-app/webda.config.jsonc";
   }

--- a/packages/core/src/stores/memory.spec.ts
+++ b/packages/core/src/stores/memory.spec.ts
@@ -32,7 +32,7 @@ class MemoryStoreTest extends StoreTest<MemoryStore> {
   }
 
   async getIdentStore(): Promise<MemoryStore<any>> {
-    const identStore = new MemoryStore("Idents", { model: "WebdaTest/Ident" });
+    const identStore = new MemoryStore("Idents", { models: ["WebdaTest/Ident"] });
     // @ts-ignore
     const original = identStore._get.bind(identStore);
     // @ts-ignore
@@ -44,7 +44,7 @@ class MemoryStoreTest extends StoreTest<MemoryStore> {
   }
 
   async getUserStore(): Promise<MemoryStore<any>> {
-    return this.addService(MemoryStore, { model: "Webda/User" }, "Users");
+    return this.addService(MemoryStore, { models: ["Webda/User"] }, "Users");
   }
 
   @test
@@ -205,7 +205,7 @@ class AdditionalMemoryTest extends WebdaApplicationTest {
   async multiModel() {
     const identStore: MemoryStore = await this.addService(
       MemoryStore,
-      { model: "Webda/Ident", strict: false },
+      { models: ["Webda/Ident"], strict: false },
       "Idents"
     );
     await identStore.create("user", new User().setUuid("user"));
@@ -225,7 +225,7 @@ class AdditionalMemoryTest extends WebdaApplicationTest {
   async migration() {
     (<Application>useApplication()).addModel("Webda/User", User);
     (<Application>useApplication()).addModel("WebdaDemo/User", DemoUser);
-    const usersStore: MemoryStore<any> = await this.addService(MemoryStore, { model: "Webda/User" });
+    const usersStore: MemoryStore<any> = await this.addService(MemoryStore, { models: ["Webda/User"] });
     for (let i = 0; i < 1200; i++) {
       await usersStore.create(`id_${i}`, { id: i });
       if (i % 10 === 0) {

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -3,7 +3,7 @@ import * as assert from "assert";
 import { stub } from "sinon";
 import { randomUUID } from "crypto";
 import { TestIdent } from "../test/objects.js";
-import { Ident, OperationContext, Store, User } from "../index.js";
+import { Ident, MemoryStore, OperationContext, Store, User } from "../index.js";
 import { CoreModel } from "../models/coremodel.js";
 import { WebdaApplicationTest } from "../test/application.js";
 import { StoreEvents, StoreNotFoundError, StoreParameters, UpdateConditionFailError } from "./store.js";
@@ -702,6 +702,28 @@ class StoreParametersTest {
       () => new StoreParameters().load({ models: ["X"], additionalModels: [] }),
       /ambiguous/i
     );
+  }
+}
+
+@suite
+class StoreFieldsMigrationTest extends WebdaApplicationTest {
+  @test
+  async populatesModelsArrayAndMetadatas() {
+    // Use the legacy `model` + `additionalModels` syntax (still in the schema).
+    // StoreParameters.load() maps them to models[] which computeParameters() walks.
+    const store = new MemoryStore("multi", { model: "Webda/Ident", additionalModels: ["Webda/User"] });
+    store.resolve();
+    assert.strictEqual((store as any)._models.length, 2);
+    assert.strictEqual((store as any)._modelMetadatas.size, 2);
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/Ident"], 0);
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
+  }
+
+  @test
+  async getModelReturnsFirstForBackCompat() {
+    const store = new MemoryStore("primaryModel", { model: "Webda/User" });
+    store.resolve();
+    assert.strictEqual(store.getModel()?.name, "User");
   }
 }
 

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -718,6 +718,7 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
     assert.strictEqual((store as any)._modelMetadatas.size, 2);
     assert.strictEqual((store as any)._modelsHierarchy["Webda/Ident"], 0);
     assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
+    assert.strictEqual(store.getModels().length, 2);
   }
 
   @test
@@ -725,6 +726,27 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
     const store = new MemoryStore("primaryModel", { model: "Webda/User" });
     store.resolve();
     assert.strictEqual(store.getModel()?.name, "User");
+  }
+
+  @test
+  async walksSubclassHierarchyForNonStrictStore() {
+    // Webda/User has Webda/SimpleUser as a subclass (verified via webda.module.json).
+    // In non-strict mode the recursive walk should add the subclass at depth 1.
+    const store = new MemoryStore("hierarchical", { models: ["Webda/User"] });
+    store.getParameters().models = ["Webda/User"];
+    store.resolve();
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/SimpleUser"], 1);
+  }
+
+  @test
+  async strictStoreSkipsSubclassWalk() {
+    // Same Webda/User parent, but strict: true should not add SimpleUser.
+    const store = new MemoryStore("strict", { models: ["Webda/User"], strict: true });
+    store.getParameters().models = ["Webda/User"];
+    store.resolve();
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
+    assert.strictEqual((store as any)._modelsHierarchy["Webda/SimpleUser"], undefined);
   }
 }
 

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "@webda/test";
+import { suite, test } from "@webda/test";
 import * as assert from "assert";
 import { stub } from "sinon";
 import { randomUUID } from "crypto";
@@ -6,7 +6,7 @@ import { TestIdent } from "../test/objects.js";
 import { Ident, OperationContext, Store, User } from "../index.js";
 import { CoreModel } from "../models/coremodel.js";
 import { WebdaApplicationTest } from "../test/application.js";
-import { StoreEvents, StoreNotFoundError, UpdateConditionFailError } from "./store.js";
+import { StoreEvents, StoreNotFoundError, StoreParameters, UpdateConditionFailError } from "./store.js";
 import { UuidModel } from "@webda/models";
 
 /**
@@ -650,6 +650,44 @@ abstract class StoreTest<T extends Store<any>> extends WebdaApplicationTest {
     }
     await (ref as any).upsert({ test: "true" });
     await (ref as any).upsert({ test: "false" });
+  }
+}
+
+@suite
+class StoreParametersTest {
+  @test
+  acceptsModelsArrayOnly() {
+    const p = new StoreParameters().load({ models: ["MyApp/User", "MyApp/Task"] });
+    assert.deepStrictEqual(p.models, ["MyApp/User", "MyApp/Task"]);
+  }
+
+  @test
+  mapsLegacyModelToModelsArray() {
+    const p = new StoreParameters().load({ model: "MyApp/User" });
+    assert.deepStrictEqual(p.models, ["MyApp/User"]);
+  }
+
+  @test
+  mapsModelPlusAdditionalToFlatArray() {
+    const p = new StoreParameters().load({
+      model: "MyApp/User",
+      additionalModels: ["MyApp/Task", "MyApp/Order"]
+    });
+    assert.deepStrictEqual(p.models, ["MyApp/User", "MyApp/Task", "MyApp/Order"]);
+  }
+
+  @test
+  throwsWhenBothModelAndModelsSet() {
+    assert.throws(
+      () => new StoreParameters().load({ model: "MyApp/User", models: ["MyApp/User"] }),
+      /ambiguous/i
+    );
+  }
+
+  @test
+  defaultsToRegistryEntryWhenNeitherSet() {
+    const p = new StoreParameters().load({});
+    assert.deepStrictEqual(p.models, ["Webda/RegistryEntry"]);
   }
 }
 

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -709,9 +709,10 @@ class StoreParametersTest {
 class StoreFieldsMigrationTest extends WebdaApplicationTest {
   @test
   async populatesModelsArrayAndMetadatas() {
-    // Use the legacy `model` + `additionalModels` syntax (still in the schema).
-    // StoreParameters.load() maps them to models[] which computeParameters() walks.
-    const store = new MemoryStore("multi", { model: "Webda/Ident", additionalModels: ["Webda/User"] });
+    const store = new MemoryStore("multi", { models: ["Webda/Ident", "Webda/User"] });
+    // filterParameters strips unknown fields from the pre-schema-regen module; set models directly
+    // to exercise computeParameters() via the canonical models[] path (not the legacy shim).
+    store.getParameters().models = ["Webda/Ident", "Webda/User"];
     store.resolve();
     assert.strictEqual((store as any)._models.length, 2);
     assert.strictEqual((store as any)._modelMetadatas.size, 2);

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -689,6 +689,20 @@ class StoreParametersTest {
     const p = new StoreParameters().load({});
     assert.deepStrictEqual(p.models, ["Webda/RegistryEntry"]);
   }
+
+  @test
+  mapsAdditionalModelsAloneToRegistryFallback() {
+    const p = new StoreParameters().load({ additionalModels: ["MyApp/Task"] });
+    assert.deepStrictEqual(p.models, ["Webda/RegistryEntry", "MyApp/Task"]);
+  }
+
+  @test
+  throwsWhenModelsCombinedWithEmptyAdditionalModels() {
+    assert.throws(
+      () => new StoreParameters().load({ models: ["X"], additionalModels: [] }),
+      /ambiguous/i
+    );
+  }
 }
 
 export { StoreTest };

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -722,13 +722,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
   }
 
   @test
-  async getModelReturnsFirstForBackCompat() {
-    const store = new MemoryStore("primaryModel", { model: "Webda/User" });
-    store.resolve();
-    assert.strictEqual(store.getModel()?.name, "User");
-  }
-
-  @test
   async walksSubclassHierarchyForNonStrictStore() {
     // Webda/User has Webda/SimpleUser as a subclass (verified via webda.module.json).
     // In non-strict mode the recursive walk should add the subclass at depth 1.

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -8,6 +8,7 @@ import { CoreModel } from "../models/coremodel.js";
 import { WebdaApplicationTest } from "../test/application.js";
 import { StoreEvents, StoreNotFoundError, StoreParameters, UpdateConditionFailError } from "./store.js";
 import { UuidModel } from "@webda/models";
+import { MemoryLogger, useWorkerOutput } from "@webda/workout";
 
 /**
  * Fake model that refuse the half of the items
@@ -701,6 +702,53 @@ class StoreParametersTest {
     assert.throws(
       () => new StoreParameters().load({ models: ["X"], additionalModels: [] }),
       /ambiguous/i
+    );
+  }
+
+  /**
+   * Capture the WARN logs emitted while running `fn` against the global WorkerOutput.
+   */
+  private captureWarnings(fn: () => void): string[] {
+    const memoryLogger = new MemoryLogger(useWorkerOutput());
+    try {
+      fn();
+    } finally {
+      memoryLogger.close();
+    }
+    return memoryLogger
+      .getLogs()
+      .map(l => l.log)
+      .filter(l => l?.level === "WARN")
+      .map(l => (l?.args ?? []).join(" "));
+  }
+
+  @test
+  emitsDeprecationWarnOnLegacyModel() {
+    const warnings = this.captureWarnings(() => new StoreParameters().load({ model: "MyApp/User" }));
+    assert.ok(
+      warnings.some(w => /deprecated/i.test(w)),
+      `expected a deprecation WARN, got: ${JSON.stringify(warnings)}`
+    );
+  }
+
+  @test
+  emitsDeprecationWarnOnLegacyAdditionalModels() {
+    const warnings = this.captureWarnings(
+      () => new StoreParameters().load({ additionalModels: ["MyApp/Task"] })
+    );
+    assert.ok(
+      warnings.some(w => /deprecated/i.test(w)),
+      `expected a deprecation WARN, got: ${JSON.stringify(warnings)}`
+    );
+  }
+
+  @test
+  noDeprecationWarnOnModelsArray() {
+    const warnings = this.captureWarnings(() => new StoreParameters().load({ models: ["MyApp/User"] }));
+    assert.strictEqual(
+      warnings.filter(w => /deprecated/i.test(w)).length,
+      0,
+      `expected no deprecation WARN, got: ${JSON.stringify(warnings)}`
     );
   }
 }

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -679,10 +679,7 @@ class StoreParametersTest {
 
   @test
   throwsWhenBothModelAndModelsSet() {
-    assert.throws(
-      () => new StoreParameters().load({ model: "MyApp/User", models: ["MyApp/User"] }),
-      /ambiguous/i
-    );
+    assert.throws(() => new StoreParameters().load({ model: "MyApp/User", models: ["MyApp/User"] }), /ambiguous/i);
   }
 
   @test
@@ -699,10 +696,7 @@ class StoreParametersTest {
 
   @test
   throwsWhenModelsCombinedWithEmptyAdditionalModels() {
-    assert.throws(
-      () => new StoreParameters().load({ models: ["X"], additionalModels: [] }),
-      /ambiguous/i
-    );
+    assert.throws(() => new StoreParameters().load({ models: ["X"], additionalModels: [] }), /ambiguous/i);
   }
 
   /**
@@ -738,9 +732,7 @@ class StoreParametersTest {
 
   @test
   emitsDeprecationWarnOnLegacyAdditionalModels() {
-    const warnings = this.captureWarnings(
-      () => new StoreParameters().load({ additionalModels: ["MyApp/Task"] })
-    );
+    const warnings = this.captureWarnings(() => new StoreParameters().load({ additionalModels: ["MyApp/Task"] }));
     assert.ok(
       warnings.some(w => /deprecated/i.test(w)),
       `expected a deprecation WARN, got: ${JSON.stringify(warnings)}`
@@ -763,9 +755,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
   @test
   async populatesModelsArrayAndMetadatas() {
     const store = new MemoryStore("multi", { models: ["Webda/Ident", "Webda/User"] });
-    // filterParameters strips unknown fields from the pre-schema-regen module; set models directly
-    // to exercise computeParameters() via the canonical models[] path (not the legacy shim).
-    store.getParameters().models = ["Webda/Ident", "Webda/User"];
     store.resolve();
     assert.strictEqual((store as any)._models.length, 2);
     assert.strictEqual((store as any)._modelMetadatas.size, 2);
@@ -779,7 +768,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
     // Webda/User has Webda/SimpleUser as a subclass (verified via webda.module.json).
     // In non-strict mode the recursive walk should add the subclass at depth 1.
     const store = new MemoryStore("hierarchical", { models: ["Webda/User"] });
-    store.getParameters().models = ["Webda/User"];
     store.resolve();
     assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
     assert.strictEqual((store as any)._modelsHierarchy["Webda/SimpleUser"], 1);
@@ -789,7 +777,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
   async strictStoreSkipsSubclassWalk() {
     // Same Webda/User parent, but strict: true should not add SimpleUser.
     const store = new MemoryStore("strict", { models: ["Webda/User"], strict: true });
-    store.getParameters().models = ["Webda/User"];
     store.resolve();
     assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
     assert.strictEqual((store as any)._modelsHierarchy["Webda/SimpleUser"], undefined);
@@ -800,7 +787,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
     // A models[] entry that resolves to no model class is skipped (TRACE) and
     // leaves the store claiming nothing — it should not throw at resolve().
     const store = new MemoryStore("unknown", { models: ["DoesNot/Exist"] });
-    store.getParameters().models = ["DoesNot/Exist"];
     store.resolve();
     assert.strictEqual(store.getModels().length, 0);
     assert.deepStrictEqual((store as any)._modelsHierarchy, {});
@@ -809,7 +795,6 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
   @test
   async setModelDefinitionHelperOverridesFirstModel() {
     const store = new MemoryStore("override", { models: ["Webda/User"] });
-    store.getParameters().models = ["Webda/User"];
     store.resolve();
     store.setModelDefinitionHelper(Ident as any);
     assert.strictEqual(store.getModels()[0], Ident);

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -723,6 +723,11 @@ class StoreParametersTest {
   }
 
   @test
+  throwsOnExposeParameter() {
+    assert.throws(() => new StoreParameters().load({ expose: true }), /Expose is not supported/);
+  }
+
+  @test
   emitsDeprecationWarnOnLegacyModel() {
     const warnings = this.captureWarnings(() => new StoreParameters().load({ model: "MyApp/User" }));
     assert.ok(
@@ -788,6 +793,26 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
     store.resolve();
     assert.strictEqual((store as any)._modelsHierarchy["Webda/User"], 0);
     assert.strictEqual((store as any)._modelsHierarchy["Webda/SimpleUser"], undefined);
+  }
+
+  @test
+  async ignoresUnknownModelId() {
+    // A models[] entry that resolves to no model class is skipped (TRACE) and
+    // leaves the store claiming nothing — it should not throw at resolve().
+    const store = new MemoryStore("unknown", { models: ["DoesNot/Exist"] });
+    store.getParameters().models = ["DoesNot/Exist"];
+    store.resolve();
+    assert.strictEqual(store.getModels().length, 0);
+    assert.deepStrictEqual((store as any)._modelsHierarchy, {});
+  }
+
+  @test
+  async setModelDefinitionHelperOverridesFirstModel() {
+    const store = new MemoryStore("override", { models: ["Webda/User"] });
+    store.getParameters().models = ["Webda/User"];
+    store.resolve();
+    store.setModelDefinitionHelper(Ident as any);
+    assert.strictEqual(store.getModels()[0], Ident);
   }
 }
 

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -491,7 +491,6 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
         useLog("WARN", `Store ${this.getName?.() ?? "unknown"}: model metadata not found for ${id}`);
         continue;
       }
-      useLog("TRACE", "METADATA", meta);
       this._models.push(model);
       this._modelMetadatas.set(meta.Identifier, meta);
       this._modelsHierarchy[meta.Identifier] = 0;

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -358,22 +358,12 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
   K,
   E
 > {
-  /**
-   * Contains the current model
-   */
-  _model: ModelClass;
-  /**
-   * Contains the current model metadata
-   */
-  _modelMetadata: ModelMetadata;
-  /**
-   * Store the manager hierarchy with their depth
-   */
+  /** All model classes managed by this store. Index 0 is the legacy "primary" model. */
+  _models: ModelClass[] = [];
+  /** Metadata for each model in `_models`, keyed by Identifier. */
+  _modelMetadatas: Map<string, ModelMetadata> = new Map();
+  /** Store the manager hierarchy with their depth */
   _modelsHierarchy: { [key: string]: number } = {};
-  /**
-   * Contains the current model type
-   */
-  _modelType: string;
 
   /**
    * Override the resolved model class for this store at runtime. Used by
@@ -383,7 +373,7 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
    * @param model - the substitute model class
    */
   setModelDefinitionHelper(model: ModelClass): void {
-    this._model = model;
+    this._models[0] = model;
   }
   /**
    * Add metrics counter
@@ -441,93 +431,72 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
   }
 
   /**
-   * Retrieve the Model and build the models hierarchy map.
+   * Retrieve the Models and build the models hierarchy map.
    *
-   * If the configured model cannot be found, or if no model was explicitly
-   * configured (store uses the default RegistryEntry fallback), the hierarchy
-   * stays empty and the store will not claim any model — preserving the
-   * pre-migration fallback behaviour for test-only or misconfigured stores.
+   * Walks `parameters.models[]` (the canonical flat list introduced in Task 1).
+   * If the list is empty or contains only the default "Webda/RegistryEntry"
+   * fallback, the hierarchy stays empty and the store will not claim any model
+   * — preserving the pre-migration fallback behaviour for test-only or
+   * misconfigured stores.
    */
   computeParameters(): void {
     super.computeParameters();
 
-    // Stores left with the default "Webda/RegistryEntry" model (and no
-    // additionalModels) should not participate in the hierarchy — they are
-    // typically the Registry fallback or test-only stores. Checking the
-    // resolved model directly avoids relying on a flag set by
-    // StoreParameters.load: addService bypasses subclass load() and
-    // constructs its parameters via the generic ServiceParameters.load,
-    // which never runs the StoreParameters override.
-    const isDefaultModel = !this.parameters.model || this.parameters.model === "Webda/RegistryEntry";
-    const hasAdditional = (this.parameters.additionalModels?.length ?? 0) > 0;
-    if (isDefaultModel && !hasAdditional) {
+    const ids = this.parameters.models ?? [];
+    // Empty / default RegistryEntry → leave hierarchy empty (preserves test-only / fallback behaviour).
+    const isOnlyDefault = ids.length === 1 && ids[0] === "Webda/RegistryEntry";
+    if (ids.length === 0 || isOnlyDefault) {
       return;
     }
 
-    // Guard: useModel throws on undefined and may return undefined/null for
-    // unknown models. Catch both so test-only or misconfigured stores stay
-    // harmless.
-    try {
-      this._model = useModel(this.parameters.model);
-    } catch {
-      this._model = undefined;
-    }
-    if (!this._model) {
-      useLog("TRACE", `Store ${this.getName?.() ?? "unknown"}: model not found: ${this.parameters.model}`);
-      return;
-    }
-    this._modelMetadata = useModelMetadata(this._model);
-    if (!this._modelMetadata) {
-      useLog("WARN", `Store ${this.getName?.() ?? "unknown"}: model metadata not found for ${this.parameters.model}`);
-      return;
-    }
-    useLog("TRACE", "METADATA", this._modelMetadata);
-    this._modelType = this._modelMetadata.Identifier;
+    this._models = [];
+    this._modelMetadatas = new Map();
+    this._modelsHierarchy = {};
 
-    // Recursively populate _modelsHierarchy for a model's subclass tree.
-    // Each subclass identifier in meta.Subclasses is a string that we resolve
-    // via useModel. We keep the minimum depth seen for each identifier.
-    const recursive = (subclassIds: string[], depth: number) => {
-      for (const id of subclassIds) {
-        this._modelsHierarchy[id] = Math.min(depth, this._modelsHierarchy[id] ?? depth);
+    // Subclasses in ModelMetadata are resolved to ModelClass objects at runtime
+    // (see Application.setModelMetadata). Accept both string IDs and ModelClass
+    // references so the hierarchy is keyed by string identifier throughout.
+    const recursive = (subclasses: (string | ModelClass)[], depth: number) => {
+      for (const entry of subclasses) {
         let subModel: ModelClass | undefined;
-        try {
-          subModel = useModel(id);
-        } catch {
-          continue;
+        let subId: string | undefined;
+        if (typeof entry === "string") {
+          subId = entry;
+          try { subModel = useModel(entry); } catch { continue; }
+        } else {
+          subModel = entry as ModelClass;
+          subId = useModelId(subModel);
         }
-        if (!subModel) continue;
+        if (!subId || !subModel) continue;
+        this._modelsHierarchy[subId] = Math.min(depth, this._modelsHierarchy[subId] ?? depth);
         const subMeta = useModelMetadata(subModel);
         if (!subMeta) continue;
         recursive(subMeta.Subclasses ?? [], depth + 1);
       }
     };
 
-    // Compute the hierarchy — reset first so re-resolve is idempotent
-    this._modelsHierarchy = {};
-    this._modelsHierarchy[this._modelMetadata.Identifier] = 0;
-    // Strict Store only stores their exact model
-    if (!this.parameters.strict) {
-      recursive(this._modelMetadata.Subclasses ?? [], 1);
-    }
-    // Add additional models (each treated as depth-0 roots with their own subtree)
-    if ((this.parameters.additionalModels ?? []).length) {
-      if (this.parameters.strict) {
-        useLog("ERROR", "Cannot add additional models in strict mode");
-      } else {
-        for (const modelType of this.parameters.additionalModels!) {
-          let addModel: ModelClass | undefined;
-          try {
-            addModel = useModel(modelType);
-          } catch {
-            continue;
-          }
-          if (!addModel) continue;
-          const addMeta = useModelMetadata(addModel);
-          if (!addMeta) continue;
-          this._modelsHierarchy[addMeta.Identifier] = 0;
-          recursive(addMeta.Subclasses ?? [], 1);
-        }
+    for (const id of ids) {
+      let model: ModelClass | undefined;
+      try {
+        model = useModel(id);
+      } catch {
+        model = undefined;
+      }
+      if (!model) {
+        useLog("TRACE", `Store ${this.getName?.() ?? "unknown"}: model not found: ${id}`);
+        continue;
+      }
+      const meta = useModelMetadata(model);
+      if (!meta) {
+        useLog("WARN", `Store ${this.getName?.() ?? "unknown"}: model metadata not found for ${id}`);
+        continue;
+      }
+      useLog("TRACE", "METADATA", meta);
+      this._models.push(model);
+      this._modelMetadatas.set(meta.Identifier, meta);
+      this._modelsHierarchy[meta.Identifier] = 0;
+      if (!this.parameters.strict) {
+        recursive(meta.Subclasses ?? [], 1);
       }
     }
   }
@@ -580,11 +549,20 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
   }
 
   /**
-   * Return Store current model
+   * Return Store current model.
+   * @deprecated Use `getModels()` instead. Returns the first model for back-compat.
    * @returns the result
    */
-  getModel(): ModelClass {
-    return this._model;
+  getModel(): ModelClass | undefined {
+    return this._models[0];
+  }
+
+  /**
+   * All models managed by this store.
+   * @returns the array of model classes managed by this store
+   */
+  getModels(): ModelClass[] {
+    return this._models;
   }
 
   /**

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -289,9 +289,14 @@ export class StoreParameters extends ServiceParameters {
     // Deprecation mapping: model + additionalModels → models[]
     const hasModels = Array.isArray(params.models);
     const hasModel = typeof params.model === "string";
-    const hasAdditional = Array.isArray(params.additionalModels) && params.additionalModels.length > 0;
+    // Presence check (not length) used for the conflict guard so that
+    // `{ models: [...], additionalModels: [] }` is still detected as ambiguous.
+    const hasAdditionalKey = Array.isArray(params.additionalModels);
+    // Length check used for the deprecation branch: an empty additionalModels
+    // alongside a bare `model` is unambiguous and should not warn on its own.
+    const hasAdditional = hasAdditionalKey && params.additionalModels.length > 0;
 
-    if (hasModels && (hasModel || hasAdditional)) {
+    if (hasModels && (hasModel || hasAdditionalKey)) {
       throw new Error(
         "StoreParameters: `models` and `model`/`additionalModels` are mutually exclusive — ambiguous configuration"
       );
@@ -309,7 +314,10 @@ export class StoreParameters extends ServiceParameters {
       this.models = ["Webda/RegistryEntry"];
     }
 
-    // Keep deprecated fields populated for any code that still reads them in this PR.
+    // When the caller passed `models[]` (or nothing at all), backfill the deprecated
+    // fields from the canonical `models[]` so any code still reading `parameters.model`
+    // or `parameters.additionalModels` keeps working. In the legacy-input branch
+    // `super.load(params)` already set both via Object.assign, so the `??=` is a no-op.
     this.model ??= this.models[0];
     this.additionalModels ??= this.models.slice(1);
 

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -218,17 +218,21 @@ export interface StoreInterface<T = any> {
  */
 export class StoreParameters extends ServiceParameters {
   /**
-   * Webda model to use within the Store
+   * Models managed by this Store.
    *
-   * @default "Webda/CoreModel"
+   * @default ["Webda/RegistryEntry"]
+   */
+  models?: string[];
+
+  /**
+   * Webda model to use within the Store.
+   * @deprecated Use `models: [model]` instead. Will be removed in 5.x.
    */
   model?: string;
+
   /**
-   * Additional models
-   *
-   * Allow this store to manage other models
-   *
-   * @default []
+   * Additional models managed by this Store.
+   * @deprecated Merge into `models[]` instead. Will be removed in 5.x.
    */
   additionalModels?: string[];
 
@@ -281,13 +285,39 @@ export class StoreParameters extends ServiceParameters {
     }
     // END_REFACTOR
     super.load(params);
-    this.model ??= "Webda/RegistryEntry";
+
+    // Deprecation mapping: model + additionalModels → models[]
+    const hasModels = Array.isArray(params.models);
+    const hasModel = typeof params.model === "string";
+    const hasAdditional = Array.isArray(params.additionalModels) && params.additionalModels.length > 0;
+
+    if (hasModels && (hasModel || hasAdditional)) {
+      throw new Error(
+        "StoreParameters: `models` and `model`/`additionalModels` are mutually exclusive — ambiguous configuration"
+      );
+    }
+
+    if (hasModels) {
+      this.models = [...params.models];
+    } else if (hasModel || hasAdditional) {
+      useLog(
+        "WARN",
+        `StoreParameters: \`model\` and \`additionalModels\` are deprecated. Use \`models: [...]\` instead.`
+      );
+      this.models = [params.model ?? "Webda/RegistryEntry", ...(params.additionalModels ?? [])];
+    } else {
+      this.models = ["Webda/RegistryEntry"];
+    }
+
+    // Keep deprecated fields populated for any code that still reads them in this PR.
+    this.model ??= this.models[0];
+    this.additionalModels ??= this.models.slice(1);
+
     this.strict ??= false;
     this.defaultModel ??= true;
     this.forceModel ??= false;
     this.slowQueryThreshold ??= 30000;
     this.modelAliases ??= {};
-    this.additionalModels ??= [];
     return this;
   }
 }

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -225,18 +225,6 @@ export class StoreParameters extends ServiceParameters {
   models?: string[];
 
   /**
-   * Webda model to use within the Store.
-   * @deprecated Use `models: [model]` instead. Will be removed in 5.x.
-   */
-  model?: string;
-
-  /**
-   * Additional models managed by this Store.
-   * @deprecated Merge into `models[]` instead. Will be removed in 5.x.
-   */
-  additionalModels?: string[];
-
-  /**
    * Allow to load object that does not have the type data
    *
    * If set to true, then the Store will only managed the defined _model and no
@@ -318,9 +306,6 @@ export class StoreParameters extends ServiceParameters {
     // fields from the canonical `models[]` so any code still reading `parameters.model`
     // or `parameters.additionalModels` keeps working. In the legacy-input branch
     // `super.load(params)` already set both via Object.assign, so the `??=` is a no-op.
-    this.model ??= this.models[0];
-    this.additionalModels ??= this.models.slice(1);
-
     this.strict ??= false;
     this.defaultModel ??= true;
     this.forceModel ??= false;
@@ -545,15 +530,6 @@ abstract class Store<K extends StoreParameters = StoreParameters, E extends Stor
       name: "queries",
       help: "Query duration"
     });
-  }
-
-  /**
-   * Return Store current model.
-   * @deprecated Use `getModels()` instead. Returns the first model for back-compat.
-   * @returns the result
-   */
-  getModel(): ModelClass | undefined {
-    return this._models[0];
   }
 
   /**

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
       "src/services/service.spec.ts",
       "src/services/serviceparameters.spec.ts",
       // "src/session/*.spec.ts",
+      "src/stores/store.spec.ts",
       //"src/stores/*.spec.ts",
       "src/templates/*.spec.ts",
       "src/test/*.spec.ts",

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -1319,8 +1319,8 @@
         "description": "Memory store",
         "properties": {
           "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
+            "deprecated": true,
+            "description": "Additional models managed by this Store.",
             "items": {
               "type": "string"
             },
@@ -1337,13 +1337,23 @@
             "type": "boolean"
           },
           "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
+            "deprecated": true,
+            "description": "Webda model to use within the Store.",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -3832,5 +3842,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "6d6c8cbfa29410b7b9d07a680a68daf2"
+  "sourceDigest": "7139a4d4ffe747dc8a98f426b613b6b9"
 }

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -1319,8 +1319,8 @@
         "description": "Memory store",
         "properties": {
           "additionalModels": {
-            "deprecated": true,
-            "description": "Additional models managed by this Store.",
+            "default": [],
+            "description": "Additional models\n\nAllow this store to manage other models",
             "items": {
               "type": "string"
             },
@@ -1337,23 +1337,13 @@
             "type": "boolean"
           },
           "model": {
-            "deprecated": true,
-            "description": "Webda model to use within the Store.",
+            "default": "Webda/CoreModel",
+            "description": "Webda model to use within the Store",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
-          },
-          "models": {
-            "default": [
-              "Webda/RegistryEntry"
-            ],
-            "description": "Models managed by this Store.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -3842,5 +3832,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "7139a4d4ffe747dc8a98f426b613b6b9"
+  "sourceDigest": "6d6c8cbfa29410b7b9d07a680a68daf2"
 }

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -1318,14 +1318,6 @@
         },
         "description": "Memory store",
         "properties": {
-          "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "defaultModel": {
             "default": true,
             "description": "When __type model not found, use the model\nIf strict is setup this parameter is not used",
@@ -1336,14 +1328,19 @@
             "description": "If set, Store will ignore the __type",
             "type": "boolean"
           },
-          "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
-            "type": "string"
-          },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -3832,5 +3829,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "6d6c8cbfa29410b7b9d07a680a68daf2"
+  "sourceDigest": "c99d82019588f27bccb5cc22f3aff997"
 }

--- a/packages/fs/src/filestore-unit.spec.ts
+++ b/packages/fs/src/filestore-unit.spec.ts
@@ -295,8 +295,8 @@ class FileBackedMapTest {
   @test
   async getWithStrictMode() {
     const strictStore = createFileStore(this.tmpDir, { strict: true });
-    // @ts-ignore - set _modelType for strict filtering
-    strictStore._modelType = "MyModel";
+    // @ts-ignore - configure hierarchy directly to mimic computeParameters()
+    strictStore._modelsHierarchy = { MyModel: 0 };
     const data = { uuid: "strict1", __type: "OtherModel" };
     fs.writeFileSync(path.join(this.tmpDir, "strict1.json"), JSON.stringify(data));
     const result = await strictStore._get("strict1");

--- a/packages/fs/src/filestore.spec.ts
+++ b/packages/fs/src/filestore.spec.ts
@@ -1,6 +1,8 @@
 import { suite, test } from "@webda/test";
 import * as assert from "assert";
-import { existsSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import pkg from "fs-extra";
 import * as sinon from "sinon";
 import { CoreModel, Store, StoreNotFoundError, UpdateConditionFailError, User } from "@webda/core";
@@ -147,6 +149,49 @@ class FileStoreTest extends StoreTest<FileStore<any>> {
     removeSync(usersStore.getParameters().folder);
     usersStore.computeParameters();
     assert.ok(existsSync(usersStore.getParameters().folder));
+  }
+
+  @test
+  async strictModeRejectsForeignType() {
+    const tmpFolder = join(tmpdir(), `webda-fs-strict-reject-${Date.now()}`);
+    mkdirSync(tmpFolder);
+    try {
+      const store: FileStore<any> = await this.addService(
+        FileStore,
+        { folder: tmpFolder, models: ["Webda/Ident"], strict: true },
+        "StrictRejectStore"
+      );
+      // Write a file directly with a __type that is NOT the configured model.
+      const uid = "strict-reject-test-uid";
+      writeFileSync(join(tmpFolder, `${uid}.json`), JSON.stringify({ __type: "Webda/User", uuid: uid }));
+      // _get should return undefined because Webda/User is not at depth 0 in _modelsHierarchy
+      const result = await store["_get"](uid, false);
+      assert.strictEqual(result, undefined, "strict mode should reject a file whose __type is not the configured model");
+    } finally {
+      rmSync(tmpFolder, { recursive: true, force: true });
+    }
+  }
+
+  @test
+  async strictModeAcceptsConfiguredType() {
+    const tmpFolder = join(tmpdir(), `webda-fs-strict-accept-${Date.now()}`);
+    mkdirSync(tmpFolder);
+    try {
+      const store: FileStore<any> = await this.addService(
+        FileStore,
+        { folder: tmpFolder, models: ["Webda/Ident"], strict: true },
+        "StrictAcceptStore"
+      );
+      // Write a file directly with the matching __type.
+      const uid = "strict-accept-test-uid";
+      writeFileSync(join(tmpFolder, `${uid}.json`), JSON.stringify({ __type: "Webda/Ident", uuid: uid }));
+      // _get should return the data because Webda/Ident is at depth 0 in _modelsHierarchy
+      const result = await store["_get"](uid, false);
+      assert.ok(result !== undefined, "strict mode should accept a file whose __type matches the configured model");
+      assert.strictEqual(result.__type, "Webda/Ident");
+    } finally {
+      rmSync(tmpFolder, { recursive: true, force: true });
+    }
   }
 }
 

--- a/packages/fs/src/filestore.spec.ts
+++ b/packages/fs/src/filestore.spec.ts
@@ -22,12 +22,12 @@ interface TestUser extends User {
 @suite
 class FileStoreTest extends StoreTest<FileStore<any>> {
   async getUserStore(): Promise<FileStore<any>> {
-    return this.addService(FileStore, { folder: "./test/data/idents", model: "Webda/User" }, "Users");
+    return this.addService(FileStore, { folder: "./test/data/idents", models: ["Webda/User"] }, "Users");
   }
 
   async getIdentStore(): Promise<FileStore<any>> {
     const identStore = new FileStore("Idents", {
-      model: "WebdaTest/Ident",
+      models: ["WebdaTest/Ident"],
       folder: "./test/data/idents"
     });
     // @ts-ignore

--- a/packages/fs/src/filestore.spec.ts
+++ b/packages/fs/src/filestore.spec.ts
@@ -166,7 +166,11 @@ class FileStoreTest extends StoreTest<FileStore<any>> {
       writeFileSync(join(tmpFolder, `${uid}.json`), JSON.stringify({ __type: "Webda/User", uuid: uid }));
       // _get should return undefined because Webda/User is not at depth 0 in _modelsHierarchy
       const result = await store["_get"](uid, false);
-      assert.strictEqual(result, undefined, "strict mode should reject a file whose __type is not the configured model");
+      assert.strictEqual(
+        result,
+        undefined,
+        "strict mode should reject a file whose __type is not the configured model"
+      );
     } finally {
       rmSync(tmpFolder, { recursive: true, force: true });
     }

--- a/packages/fs/src/filestore.ts
+++ b/packages/fs/src/filestore.ts
@@ -202,7 +202,7 @@ export class FileStore<K extends FileStoreParameters = FileStoreParameters> exte
       .sort();
 
     // Use the repository for this store's model to simulate a find
-    const repo = this.getRepository(this._model) as MemoryRepository<any>;
+    const repo = this.getRepository(this._models[0]) as MemoryRepository<any>;
     return MemoryRepository.simulateFind(query as any, files, repo as any);
   }
 

--- a/packages/fs/src/filestore.ts
+++ b/packages/fs/src/filestore.ts
@@ -389,7 +389,7 @@ export class FileStore<K extends FileStoreParameters = FileStoreParameters> exte
     const res = await this._exists(uid);
     if (res) {
       const data = JSON.parse(fs.readFileSync(this.file(uid)).toString());
-      if (data.__type !== this._modelType && this.parameters.strict) {
+      if (this.parameters.strict && this._modelsHierarchy[data.__type] !== 0) {
         return undefined;
       }
       return data;

--- a/packages/fs/webda.module.json
+++ b/packages/fs/webda.module.json
@@ -153,8 +153,8 @@
         "description": "Configuration parameters for the JSON-file-backed store.",
         "properties": {
           "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
+            "deprecated": true,
+            "description": "Additional models managed by this Store.",
             "items": {
               "type": "string"
             },
@@ -182,13 +182,23 @@
             "type": "boolean"
           },
           "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
+            "deprecated": true,
+            "description": "Webda model to use within the Store.",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -304,5 +314,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "c604b24ba0b9ea0416461a6abf35857f"
+  "sourceDigest": "aeb3db279a38d6f834e626b0cee3d51e"
 }

--- a/packages/fs/webda.module.json
+++ b/packages/fs/webda.module.json
@@ -153,8 +153,8 @@
         "description": "Configuration parameters for the JSON-file-backed store.",
         "properties": {
           "additionalModels": {
-            "deprecated": true,
-            "description": "Additional models managed by this Store.",
+            "default": [],
+            "description": "Additional models\n\nAllow this store to manage other models",
             "items": {
               "type": "string"
             },
@@ -182,23 +182,13 @@
             "type": "boolean"
           },
           "model": {
-            "deprecated": true,
-            "description": "Webda model to use within the Store.",
+            "default": "Webda/CoreModel",
+            "description": "Webda model to use within the Store",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
-          },
-          "models": {
-            "default": [
-              "Webda/RegistryEntry"
-            ],
-            "description": "Models managed by this Store.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -314,5 +304,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "aeb3db279a38d6f834e626b0cee3d51e"
+  "sourceDigest": "c604b24ba0b9ea0416461a6abf35857f"
 }

--- a/packages/fs/webda.module.json
+++ b/packages/fs/webda.module.json
@@ -152,14 +152,6 @@
         },
         "description": "Configuration parameters for the JSON-file-backed store.",
         "properties": {
-          "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "beautify": {
             "description": "Parameter sent to JSON.stringify when storing the json",
             "type": [
@@ -181,14 +173,19 @@
             "description": "If set, Store will ignore the __type",
             "type": "boolean"
           },
-          "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
-            "type": "string"
-          },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -304,5 +301,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "c604b24ba0b9ea0416461a6abf35857f"
+  "sourceDigest": "aeb3db279a38d6f834e626b0cee3d51e"
 }

--- a/packages/postgres/src/postgresstore.spec.ts
+++ b/packages/postgres/src/postgresstore.spec.ts
@@ -2,6 +2,7 @@ import { suite, test } from "@webda/test";
 import * as assert from "node:assert";
 import pg from "pg";
 import { WebdaApplicationTest } from "@webda/core/lib/test";
+import { useModel } from "@webda/core";
 import PostgresStore from "./postgresstore.js";
 
 const params = {
@@ -146,5 +147,44 @@ export class PostgresStoreSmokeTest extends WebdaApplicationTest {
     });
     this.store!.getParameters().views = [".*"];
     this.store!.getParameters().viewPrefix = "";
+  }
+
+}
+
+/**
+ * Unit tests for resolveTable() that do not require a live PostgreSQL connection.
+ * Extends WebdaApplicationTest only for its model registry (useModel / useModelMetadata),
+ * but does NOT call addService() — so the DB-connect path is never triggered.
+ */
+@suite
+export class PostgresStoreResolveTableTest extends WebdaApplicationTest {
+  @test
+  async resolveTableSingleModelUsesParametersTable() {
+    const store = new PostgresStore("singleTable", { models: ["Webda/Ident"], table: "idents" });
+    // Bypass resolve()/init() — we only test the table-name resolution logic.
+    // Set parameters.models directly (schema workaround: Task 7 regenerates it).
+    store.getParameters().models = ["Webda/Ident"];
+    assert.strictEqual(store.resolveTable(useModel("Webda/Ident")), "idents");
+  }
+
+  @test
+  async resolveTableMultiModelIgnoresParametersTable() {
+    const store = new PostgresStore("multiTable", {
+      models: ["Webda/Ident", "Webda/User"],
+      table: "idents"
+    });
+    store.getParameters().models = ["Webda/Ident", "Webda/User"];
+    assert.strictEqual(store.resolveTable(useModel("Webda/Ident")), "webda_ident");
+    assert.strictEqual(store.resolveTable(useModel("Webda/User")), "webda_user");
+  }
+
+  @test
+  async resolveTableExplicitTablesMapWins() {
+    const store = new PostgresStore("explicitTable", {
+      models: ["Webda/User"],
+      tables: { "Webda/User": "users_v2" }
+    });
+    store.getParameters().models = ["Webda/User"];
+    assert.strictEqual(store.resolveTable(useModel("Webda/User")), "users_v2");
   }
 }

--- a/packages/postgres/src/postgresstore.spec.ts
+++ b/packages/postgres/src/postgresstore.spec.ts
@@ -148,7 +148,6 @@ export class PostgresStoreSmokeTest extends WebdaApplicationTest {
     this.store!.getParameters().views = [".*"];
     this.store!.getParameters().viewPrefix = "";
   }
-
 }
 
 /**
@@ -161,9 +160,6 @@ export class PostgresStoreResolveTableTest extends WebdaApplicationTest {
   @test
   async resolveTableSingleModelUsesParametersTable() {
     const store = new PostgresStore("singleTable", { models: ["Webda/Ident"], table: "idents" });
-    // Bypass resolve()/init() — we only test the table-name resolution logic.
-    // Set parameters.models directly (schema workaround: Task 7 regenerates it).
-    store.getParameters().models = ["Webda/Ident"];
     assert.strictEqual(store.resolveTable(useModel("Webda/Ident")), "idents");
   }
 
@@ -173,7 +169,6 @@ export class PostgresStoreResolveTableTest extends WebdaApplicationTest {
       models: ["Webda/Ident", "Webda/User"],
       table: "idents"
     });
-    store.getParameters().models = ["Webda/Ident", "Webda/User"];
     assert.strictEqual(store.resolveTable(useModel("Webda/Ident")), "webda_ident");
     assert.strictEqual(store.resolveTable(useModel("Webda/User")), "webda_user");
   }
@@ -184,7 +179,6 @@ export class PostgresStoreResolveTableTest extends WebdaApplicationTest {
       models: ["Webda/User"],
       tables: { "Webda/User": "users_v2" }
     });
-    store.getParameters().models = ["Webda/User"];
     assert.strictEqual(store.resolveTable(useModel("Webda/User")), "users_v2");
   }
 }

--- a/packages/postgres/src/postgresstore.spec.ts
+++ b/packages/postgres/src/postgresstore.spec.ts
@@ -53,7 +53,7 @@ export class PostgresStoreSmokeTest extends WebdaApplicationTest {
         ...params,
         autoCreateTable: true,
         table: "smoke_idents",
-        model: "Webda/Ident"
+        models: ["Webda/Ident"]
       } as any,
       "smoke"
     );
@@ -112,7 +112,7 @@ export class PostgresStoreSmokeTest extends WebdaApplicationTest {
         usePool: false,
         autoCreateTable: false,
         table: "smoke_idents",
-        model: "Webda/Ident"
+        models: ["Webda/Ident"]
       } as any,
       "smoke_single"
     );

--- a/packages/postgres/src/postgresstore.ts
+++ b/packages/postgres/src/postgresstore.ts
@@ -101,6 +101,12 @@ export class PostgresStore<K extends PostgresParameters = PostgresParameters> ex
    * @override
    */
   async init(): Promise<this> {
+    if (this.parameters.table && (this.parameters.models?.length ?? 0) > 1) {
+      useLog(
+        "WARN",
+        `PostgresStore "${this.getName()}": parameters.table is ignored when more than one model is configured. Use parameters.tables[id] instead.`
+      );
+    }
     if (this.parameters.usePool) {
       this.client = acquirePool(this.parameters.postgresqlServer as PoolConfig);
       this.ownsPool = true;
@@ -134,7 +140,7 @@ export class PostgresStore<K extends PostgresParameters = PostgresParameters> ex
    *
    * Resolution order:
    * 1. `parameters.tables[meta.Identifier]` — explicit per-model override
-   * 2. Primary model (matching `_modelMetadata.Identifier`) → `parameters.table`
+   * 2. Single-model back-compat: when only one model is configured, `parameters.table` maps to it
    * 3. Default — model identifier lowercased with "/" replaced by "_"
    *
    * @param model - the model class to resolve the table for
@@ -149,11 +155,11 @@ export class PostgresStore<K extends PostgresParameters = PostgresParameters> ex
     if (this.parameters.tables?.[meta.Identifier]) {
       return this.parameters.tables[meta.Identifier];
     }
-    // Primary model uses the configured table name
-    if (this._modelMetadata && meta.Identifier === this._modelMetadata.Identifier) {
+    // Single-model back-compat: parameters.table maps to the one model
+    if (this.parameters.models?.length === 1 && this.parameters.table) {
       return this.parameters.table;
     }
-    // Default: identifier lowercased, "/" → "_"
+    // Default derivation
     return meta.Identifier.toLowerCase().replace(/\//g, "_");
   }
 

--- a/packages/postgres/webda.module.json
+++ b/packages/postgres/webda.module.json
@@ -2232,8 +2232,8 @@
         },
         "properties": {
           "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
+            "deprecated": true,
+            "description": "Additional models managed by this Store.",
             "items": {
               "type": "string"
             },
@@ -2258,13 +2258,23 @@
             "type": "boolean"
           },
           "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
+            "deprecated": true,
+            "description": "Webda model to use within the Store.",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -2390,5 +2400,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "b978479cb9042a8fefb9146a86c95666"
+  "sourceDigest": "d9dfe066ac2e66d394a64fc06189b747"
 }

--- a/packages/postgres/webda.module.json
+++ b/packages/postgres/webda.module.json
@@ -2232,8 +2232,8 @@
         },
         "properties": {
           "additionalModels": {
-            "deprecated": true,
-            "description": "Additional models managed by this Store.",
+            "default": [],
+            "description": "Additional models\n\nAllow this store to manage other models",
             "items": {
               "type": "string"
             },
@@ -2258,23 +2258,13 @@
             "type": "boolean"
           },
           "model": {
-            "deprecated": true,
-            "description": "Webda model to use within the Store.",
+            "default": "Webda/CoreModel",
+            "description": "Webda model to use within the Store",
             "type": "string"
           },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
-          },
-          "models": {
-            "default": [
-              "Webda/RegistryEntry"
-            ],
-            "description": "Models managed by this Store.",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -2400,5 +2390,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "d9dfe066ac2e66d394a64fc06189b747"
+  "sourceDigest": "b978479cb9042a8fefb9146a86c95666"
 }

--- a/packages/postgres/webda.module.json
+++ b/packages/postgres/webda.module.json
@@ -2231,14 +2231,6 @@
           }
         },
         "properties": {
-          "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "autoCreateTable": {
             "default": true,
             "description": "Auto create table if not exists",
@@ -2257,14 +2249,19 @@
             "description": "If set, Store will ignore the __type",
             "type": "boolean"
           },
-          "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
-            "type": "string"
-          },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,
@@ -2390,5 +2387,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "b978479cb9042a8fefb9146a86c95666"
+  "sourceDigest": "d9dfe066ac2e66d394a64fc06189b747"
 }

--- a/packages/runtime/src/services/invitationservice.spec.ts
+++ b/packages/runtime/src/services/invitationservice.spec.ts
@@ -97,7 +97,7 @@ class InvitationTest extends WebdaInternalTest {
     await super.before();
 
     this.store = this.webda.getService<Store>("Companies");
-    this.store._model = <any>MyCompany;
+    this.store.setModelDefinitionHelper(<any>MyCompany);
 
     this.service = await this.addService(
       InvitationService,

--- a/packages/runtime/webda.module.json
+++ b/packages/runtime/webda.module.json
@@ -180,14 +180,6 @@
         },
         "description": "Configuration for MigrationStore — specifies the source and destination stores",
         "properties": {
-          "additionalModels": {
-            "default": [],
-            "description": "Additional models\n\nAllow this store to manage other models",
-            "items": {
-              "type": "string"
-            },
-            "type": "array"
-          },
           "defaultModel": {
             "default": true,
             "description": "When __type model not found, use the model\nIf strict is setup this parameter is not used",
@@ -202,14 +194,19 @@
             "description": "From store",
             "type": "string"
           },
-          "model": {
-            "default": "Webda/CoreModel",
-            "description": "Webda model to use within the Store",
-            "type": "string"
-          },
           "modelAliases": {
             "$ref": "#/definitions/modelAliases",
             "description": "Model Aliases to allow easier rename of Model"
+          },
+          "models": {
+            "default": [
+              "Webda/RegistryEntry"
+            ],
+            "description": "Models managed by this Store.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "noCache": {
             "default": false,


### PR DESCRIPTION
## Summary

First of three PRs for the Repository concept refactor. This PR introduces the flat `models: string[]` parameter on `StoreParameters`, migrates `Store` internals from `_model`/`_modelMetadata`/`_modelType` to `_models[]`/`_modelMetadatas` Map, and updates downstream stores (`fs`, `postgres`, `runtime`) to match.

Spec: [`docs/superpowers/specs/2026-05-09-repository-design.md`](docs/superpowers/specs/2026-05-09-repository-design.md) (local-only — gitignored).
Plan: [`docs/superpowers/plans/2026-05-09-repository-design.md`](docs/superpowers/plans/2026-05-09-repository-design.md) (local-only — gitignored).

## What's in this PR (Tasks 1–5 of 8)

- **Task 1** — `StoreParameters` accepts `models: string[]` alongside legacy `model` + `additionalModels`; deprecation `WARN` log fires on legacy use; ambiguity guard throws when both shapes are set.
- **Task 2** — `Store` class migrated to `_models: ModelClass[]` and `_modelMetadatas: Map<string, ModelMetadata>`. `_modelType` dropped. New `getModels()` accessor; `getModel()` deprecated. `computeParameters()` rewritten to walk `parameters.models[]`. Latent bug fixed in `recursive()` subclass walker (the runtime type from `Application.setModelMetadata` is `(string | ModelClass)[]`, not `string[]` as the type declared).
- **Task 3** — `FileStore._get()` strict-mode `__type` check rewritten to use `_modelsHierarchy` (replaces dropped `_modelType` reference).
- **Task 4** — `PostgresStore.resolveTable()` migrated off `_modelMetadata`; `parameters.table` now treated as a single-model shortcut, with `WARN` log when set with multiple models.
- **Task 5** — Final `_model`/`_modelType` references in `fs/filestore.ts:205`, `fs/filestore-unit.spec.ts:299`, `runtime/invitationservice.spec.ts:100` migrated.

## What's not in this PR (deferred)

- **Task 6** (migrate spec configs from `model:` to `models:`) — cosmetic; deprecation shim keeps existing configs working.
- **Task 7** (regenerate `webda.module.json` schemas) — surfaced a load-bearing regression where the legacy `model: { default: "Webda/CoreModel" }` schema default is essential for framework-loaded stores to claim every model. Reverted in commit `ce6f4112`. Needs a follow-up architectural fix.
- **Task 8** (final verification) — pending Task 7.

PRs 2 (Repository event re-emission) and 3 (API positioning / docs) follow this one.

## Backward compatibility

- All existing `{ model: "X", additionalModels: [...] }` configs keep working via the deprecation shim. A `WARN` log fires once per service noting the migration path.
- `getModel()` still returns the first model for back-compat (marked `@deprecated`).
- `useStore()` is unchanged in this PR.

## Test plan

- [x] `pnpm --filter @webda/core test` — 554 passed, 1 todo (was 550 before this PR; 4 new tests added).
- [x] `pnpm --filter @webda/fs test` — 123 passed (was 122; 1 new strict-mode test).
- [x] `pnpm --filter @webda/postgres test` — 3 new `resolveTable` tests pass; pre-existing PostgresStoreSmokeTest failures unrelated (DB connectivity).
- [ ] CI build green (TBD on push).

## How this was built

Each task: TDD (failing test → implementation → passing test → commit). Two-stage subagent review per task (spec compliance, then code quality), with fix loops where reviewers found issues. Two follow-up commits for code-review feedback land on top of the original task commits where applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — PR 1 completed (Tasks 6–8)

The three deferred tasks are now done; PR 1 is feature-complete.

- **Task 6 (spec config migration)** — migrated the canonical Store configs in `core` (memory, coremodel, oauth), `fs` (filestore) and `postgres` (smoke) specs from `{ model: "X" }` to `{ models: ["X"] }`. Deprecated-shape coverage is retained: `memory.spec` `additionalModels()`, `filestore-unit` `loadParameters()`, and the `StoreParameters.load()` compat-matrix unit tests still exercise the legacy `model` + `additionalModels` path. Added `MemoryLogger`-based assertions that the deprecation `WARN` fires on legacy input and stays silent on `models[]`.

- **Task 7 (schema regeneration) — the "load-bearing regression" was a phantom.** Investigated the feared `model: { default: "Webda/CoreModel" }` default: the compiler-generated `loadParameters()` builds params via `new StoreParameters().load(data)` with **no JSON-schema default injection**, and service creation does **no boot-time schema validation** — so that default was documentation-only and never claimed models at runtime. Confirmed empirically (core was already regenerated and all tests pass). Force-regenerated the stale `fs`/`postgres`/`runtime` schemas (`webdac` skips regen when a package's own source digest is unchanged, so packages that merely inline `StoreParameters` never picked up the change). Legacy `{ model: "X" }` configs keep working through the `load()` shim regardless.
  - `aws`/`gcp`/`mongodb` are **out of scope**: untouched by this branch and currently non-compiling for pre-existing/unrelated reasons (type drift, incomplete worktree deps). Their schemas remain stale as before this PR.

- **Task 8 (verification)** — `@webda/core` 559 passed / 1 todo (store.ts coverage up to 84.8% stmts, 71.4% fns, 89.2% lines), `@webda/fs` 123 passed, `@webda/postgres` `resolveTable`/non-DB tests pass (the 21 failures are pre-existing `ECONNREFUSED` — no local Postgres). Lint and prettier clean on touched packages; in-scope packages build clean. Also removed the now-obsolete `parameters.models = [...]` test workarounds that only existed to compensate for the pre-Task-7 stale schema.

### Note on backward compatibility

Commit `082ca41b` removed the deprecated `model` / `additionalModels` typed fields and `getModel()` from `StoreParameters`/`Store`, keeping only the `load()` input shim. Runtime back-compat for legacy configs is preserved by that shim. Because store schemas use `additionalProperties: false`, the regenerated schema no longer lists `model`/`additionalModels`, so the **config UI / tooling** would flag a legacy `model:` config — runtime is unaffected. This matches the direction set by `082ca41b`.
