### PR TITLE
feat: Repository typed events, consumer migration + API positioning (PR 2+3 of 3)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -65,7 +65,7 @@ webda new-deployment          # Create deployment configuration
   "imports": ["./webda.import.jsonc"],  // Modular config loading
   "services": {
     "myStore": {
-      "model": "MyApp/MyModel",
+      "models": ["MyApp/MyModel"],    // flat models[] (replaces deprecated model + additionalModels)
       "type": "MemoryStore"           // Auto-resolves to Webda/MemoryStore
     }
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,15 +89,17 @@ export class TaskNotificationService extends Service {
 **CRITICAL**: ALWAYS use dependency injection. NEVER manually instantiate services.
 
 ```typescript
-// ✅ CORRECT: Use dependency injection
+// ✅ CORRECT: Use dependency injection for services
 @Bean
 export class MyService extends Service {
-  @Inject("myStore")
-  store: Store;
-
   @Inject("mailer")
   mailer: Mailer;
+
+  @Inject("myQueue")
+  queue: Queue;
 }
+// Note: for persistence, do NOT @Inject a Store — use the model directly
+// (Task.create(), Task.ref(uuid).get()) or useRepository(Task). See "Repository Pattern" below.
 
 // ❌ WRONG: Manual instantiation
 const store = new MemoryStore(); // NEVER do this
@@ -153,7 +155,7 @@ Configuration follows a resolution hierarchy:
   "services": {
     "myStore": {
       "type": "MemoryStore",
-      "model": "MyApp/MyModel"
+      "models": ["MyApp/MyModel"]
     }
   },
   "parameters": {
@@ -471,37 +473,47 @@ export class MyModel extends CoreModel {
 
 ## Common Patterns
 
-### 1. Store Pattern (Database Abstraction)
+### 1. Repository Pattern (Database Abstraction)
+
+Repositories are the canonical persistence API. Each model class has exactly one Repository, produced and registered by a Store service that owns the underlying backend.
 
 ```typescript
-// Define store in configuration
+// Define stores in configuration — internal infrastructure
 {
   "services": {
-    "taskStore": {
-      "type": "MemoryStore",  // or DynamoStore, MongoStore, PostgresStore
-      "model": "MyApp/Task"
+    "db": {
+      "type": "MemoryStore",  // or DynamoStore, MongoStore, PostgresStore, FileStore
+      "models": ["MyApp/Task", "MyApp/User"]
     }
   }
 }
 
-// Use in service
+// In app code — never reference the store, use the model
 @Bean
 export class TaskService extends Service {
-  @Inject("taskStore")
-  store: Store<Task>;
-
   async getTask(uuid: string): Promise<Task> {
-    return this.store.get(uuid);
+    return Task.ref(uuid).get();
   }
 
   async createTask(data: Partial<Task>): Promise<Task> {
-    const task = new Task();
-    Object.assign(task, data);
-    await this.store.save(task);
-    return task;
+    return Task.create(data);
+  }
+
+  async findOpenTasks(): Promise<Task[]> {
+    const result = await Task.query("status = 'open'");
+    return result.results;
+  }
+
+  // Need the Repository directly (e.g. to register a listener)?
+  async onTaskCreated(): Promise<void> {
+    useRepository(Task).on("Created", evt => {
+      /* react to evt.object_id / evt.object */
+    });
   }
 }
 ```
+
+> **Stores are internal.** App code uses `Model.ref/create/query` or `useRepository(Model)`. `@Inject("storeName")` for stores is deprecated for app code; the `Store` class and `StoreParameters` are `@internal`. Repository typed events (`Created`/`Updated`/`Patched`/`Deleted`/`PartialUpdated`) are reached via `useRepository(Model).on(...)`.
 
 ### 2. Event Pattern
 
@@ -571,7 +583,7 @@ export class Document extends CoreModel {
   "services": {
     "documentStore": {
       "type": "FileStore",
-      "model": "MyApp/Document",
+      "models": ["MyApp/Document"],
       "folder": "./uploads"
     },
     "binaryService": {

--- a/docs/pages/Concepts/Stores/Repositories.md
+++ b/docs/pages/Concepts/Stores/Repositories.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 1
+---
+
+# Repositories
+
+A **Repository** is the typed CRUD/query surface for a single model. It is the
+canonical persistence API in Webda: application code interacts with persistence
+through Repositories — never directly with [Stores](./Stores.md), which are
+internal infrastructure that own a backend connection and produce Repositories.
+
+Each model class has exactly one Repository, created and registered by the Store
+that owns the model's backend.
+
+## Reaching a Repository
+
+Three equivalent paths — prefer the static model methods:
+
+```typescript
+// 1. Static methods on the model (preferred)
+const user = await User.create({ name: "Alice" });
+const result = await User.query("name = 'Alice'");
+const same = await User.ref(user.getUuid()).get();
+
+// 2. The hook — when you need the Repository object itself
+import { useRepository } from "@webda/core";
+const repo = useRepository(User);
+await repo.create({ name: "Bob" });
+
+// 3. Inside a Service — Repositories are NOT @Inject-able; use one of the above.
+```
+
+> Configuring which backend stores a model is a [Store](./Stores.md) concern,
+> declared in `webda.config`. App code does not name the store.
+
+## CRUD operations
+
+```typescript
+// Create
+const post = await Post.create({ title: "Hello", status: "draft" });
+
+// Read
+const fetched = await Post.ref(post.getUuid()).get();
+
+// Query (WebdaQL)
+const drafts = await Post.query("status = 'draft' ORDER BY title ASC LIMIT 20");
+
+// Update / patch
+await Post.ref(post.getUuid()).patch({ status: "published" });
+
+// Delete
+await Post.ref(post.getUuid()).delete();
+
+// Iterate large result sets without paginating by hand
+for await (const p of Post.iterate("status = 'published'")) {
+  // ...
+}
+```
+
+## Events
+
+Repositories emit typed events around every operation. Register listeners on the
+Repository — the events fire whether the write came from `Model.create()`,
+`useRepository(Model).create()`, or any other path.
+
+| Pre-event   | Post-event       | Payload                                  |
+| ----------- | ---------------- | ---------------------------------------- |
+| `Create`    | `Created`        | `{ object_id, object }`                  |
+| `Update`    | `Updated`        | `{ object_id, object, previous }`        |
+| `Patch`     | `Patched`        | `{ object_id, object, previous }`        |
+| `Delete`    | `Deleted`        | `{ object_id }`                          |
+| `PartialUpdate` | `PartialUpdated` | `{ object_id, partial_update }`      |
+| `Query`     | `Queried`        | `{ query, results, continuationToken? }` |
+
+```typescript
+import { useRepository } from "@webda/core";
+
+useRepository(User).on("Created", evt => {
+  console.log("created", evt.object_id);
+});
+```
+
+> The legacy aggregate `Store.*` events and the `Store`/`StoreParameters` types
+> are `@internal`. New code listens on the Repository's typed events instead.
+
+## Interface
+
+The `Repository<T>` interface (and its segregated sub-interfaces
+`CoreRepository`, `Updatable`, `AtomicOperations`, `CollectionOperations`) live
+in `@webda/models`. The interface is frozen — concrete implementations
+(`MemoryRepository`, `PostgresRepository`, …) live in their Store packages.

--- a/docs/pages/Concepts/Stores/Stores.md
+++ b/docs/pages/Concepts/Stores/Stores.md
@@ -1,8 +1,20 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 
-# Stores
+# Stores (storage backends — advanced)
+
+:::note
+
+`Store` is the **internal infrastructure** that owns a backend instance (a DB
+connection or pool, a bucket) and produces [Repositories](./Repositories.md).
+**Application code uses [Repositories](./Repositories.md)** —
+`Model.create()` / `Model.ref(uuid).get()` / `Model.query()` or
+`useRepository(Model)` — and never references a Store by name. This page is for
+store-package authors and power-user paths. The `Store` class and
+`StoreParameters` are tagged `@internal`.
+
+:::
 
 The store services allow you to store object in a NoSQL database it handles for you mapping between objects. Objects are mapped to a model to allow security policy and schema verification.
 

--- a/packages/core/src/core/core.spec.ts
+++ b/packages/core/src/core/core.spec.ts
@@ -30,7 +30,11 @@ class CoreTest extends WebdaInternalTest {
   async registry() {
     const registry = useRegistry();
     await registry.put("test", { anyData: "plop" });
-    const test = JSON.parse((<MemoryRepository<any>>registry.getRepository())["storage"].get("test")!);
+    // getRepository() now returns an EventRepository wrapping the MemoryRepository;
+    // unwrap to reach the backing storage map.
+    const repo: any = registry.getRepository();
+    const backing = (repo.repository ?? repo) as MemoryRepository<any>;
+    const test = JSON.parse(backing["storage"].get("test")!);
     assert.strictEqual(test.$serializer?.type, "@webda/models/Webda/RegistryEntry");
     assert.strictEqual((await registry.get("test")).anyData, "plop");
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export * from "./core/hooks.js";
 export * from "./cache/cache.js";
 export * from "./stores/istore.js";
 export * from "./stores/memory.js";
-export { MemoryRepository, EventRepository } from "@webda/models";
+export { MemoryRepository, EventRepository, useRepository } from "@webda/models";
 export type { ModelClass, Repository } from "@webda/models";
 export * from "./stores/store.js";
 export * from "./utils/abstractdeployer.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,7 @@ export * from "./core/hooks.js";
 export * from "./cache/cache.js";
 export * from "./stores/istore.js";
 export * from "./stores/memory.js";
-export { MemoryRepository } from "@webda/models";
+export { MemoryRepository, EventRepository } from "@webda/models";
 export type { ModelClass, Repository } from "@webda/models";
 export * from "./stores/store.js";
 export * from "./utils/abstractdeployer.js";

--- a/packages/core/src/stores/memory.ts
+++ b/packages/core/src/stores/memory.ts
@@ -5,7 +5,7 @@ import { Readable, Writable } from "node:stream";
 import { createGzip } from "node:zlib";
 import { GunzipConditional } from "@webda/utils";
 import { Store, StoreParameters } from "./store.js";
-import { MemoryRepository, type ModelClass, type Repository } from "@webda/models";
+import { EventRepository, MemoryRepository, type ModelClass, type Repository } from "@webda/models";
 import { InstanceCache } from "../cache/cache.js";
 import { useModelMetadata } from "../core/hooks.js";
 
@@ -334,6 +334,10 @@ export class MemoryStore<K extends MemoryStoreParameters = MemoryStoreParameters
   @InstanceCache()
   getRepository<T extends ModelClass>(model: T): Repository<T> {
     // Use our own storage to allow persistence
-    return new MemoryRepository<T>(model, useModelMetadata(model).PrimaryKey, undefined, this.storage);
+    const pks = useModelMetadata(model).PrimaryKey;
+    const inner = new MemoryRepository<T>(model, pks, undefined, this.storage);
+    // Wrap in EventRepository so typed CRUD events (Created/Updated/...) fire;
+    // consumers reach them via useRepository(model).on(...).
+    return new EventRepository<T>(model, pks, inner) as unknown as Repository<T>;
   }
 }

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -7,7 +7,7 @@ import { Ident, MemoryStore, OperationContext, Store, User } from "../index.js";
 import { CoreModel } from "../models/coremodel.js";
 import { WebdaApplicationTest } from "../test/application.js";
 import { StoreEvents, StoreNotFoundError, StoreParameters, UpdateConditionFailError } from "./store.js";
-import { UuidModel } from "@webda/models";
+import { UuidModel, useRepository } from "@webda/models";
 import { MemoryLogger, useWorkerOutput } from "@webda/workout";
 
 /**
@@ -813,6 +813,18 @@ class StoreRepositoryEventsTest extends WebdaApplicationTest {
     await repo.create({ uuid: "evt-user-1" } as any);
     assert.strictEqual(seen.length, 1);
     assert.strictEqual(seen[0].object_id, "evt-user-1");
+  }
+
+  @test
+  async useRepositoryListenerFiresOnModelCreate() {
+    // The consumer contract: listen on the registered repository via
+    // useRepository(Model) and receive typed events from Model.create().
+    await this.addService(MemoryStore, { models: ["Webda/User"] }, "UserEvents");
+    const seen: any[] = [];
+    useRepository(User).on("Created", payload => seen.push(payload));
+    await User.create({ uuid: "evt-int-user" } as any);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].object_id, "evt-int-user");
   }
 }
 

--- a/packages/core/src/stores/store.spec.ts
+++ b/packages/core/src/stores/store.spec.ts
@@ -801,4 +801,19 @@ class StoreFieldsMigrationTest extends WebdaApplicationTest {
   }
 }
 
+@suite
+class StoreRepositoryEventsTest extends WebdaApplicationTest {
+  @test
+  async repositoryEmitsTypedCreatedEvent() {
+    const store = new MemoryStore("evtCreated", { models: ["Webda/User"] });
+    store.resolve();
+    const repo = store.getRepository(User);
+    const seen: any[] = [];
+    repo.on("Created", payload => seen.push(payload));
+    await repo.create({ uuid: "evt-user-1" } as any);
+    assert.strictEqual(seen.length, 1);
+    assert.strictEqual(seen[0].object_id, "evt-user-1");
+  }
+}
+
 export { StoreTest };

--- a/packages/core/src/stores/store.ts
+++ b/packages/core/src/stores/store.ts
@@ -159,6 +159,8 @@ export interface EventStorePartialUpdated<T extends Model = Model> {
 
 /**
  * Represent a query result on the Store
+ *
+ * @internal — Store-internal type. App code queries via `Model.query()` / `useRepository(Model).query()`.
  */
 export interface StoreFindResult<T> {
   /**
@@ -183,6 +185,8 @@ export interface StoreFindResult<T> {
  * A Store is low-level storage service
  *
  * It does not handle any business logic, only CRUD operations
+ *
+ * @internal — Store-internal contract. App code uses `Repository<T>` from `@webda/models`.
  */
 export interface StoreInterface<T = any> {
   create(uuid: PrimaryKey<any>, object: any): Promise<any>;
@@ -215,6 +219,9 @@ export interface StoreInterface<T = any> {
 
 /**
  * Store parameter
+ *
+ * @internal — Store configuration schema. Authored in `webda.config`/deployment
+ * files; not consumed by app code directly.
  */
 export class StoreParameters extends ServiceParameters {
   /**
@@ -315,6 +322,12 @@ export class StoreParameters extends ServiceParameters {
   }
 }
 
+/**
+ * Aggregate `Store.*` event map.
+ *
+ * @internal — Store-internal type. App code listens on typed repository events
+ * via `useRepository(Model).on("Created" | "Updated" | ...)`.
+ */
 export type StoreEvents = {
   "Store.PartialUpdated": EventStorePartialUpdated;
   "Store.Created": EventStoreCreated;
@@ -337,6 +350,9 @@ export type StoreEvents = {
  *   Store.Action: When an action will be done on an object
  *   Store.Actioned: When an action has been done on an object
  *
+ * @internal — Subclassed by store packages only. App code never references a
+ * Store directly: use `useRepository(Model)` or static model methods
+ * (`Model.create()`, `Model.query()`, `Model.ref()`).
  * @category CoreServices
  */
 abstract class Store<K extends StoreParameters = StoreParameters, E extends StoreEvents = StoreEvents> extends Service<

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -3829,5 +3829,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "498ee74af54b6d48649fd09269b02bfe"
+  "sourceDigest": "e19111f71783e691cbd3cd29148374ce"
 }

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -3829,5 +3829,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "c99d82019588f27bccb5cc22f3aff997"
+  "sourceDigest": "498ee74af54b6d48649fd09269b02bfe"
 }

--- a/packages/core/webda.module.json
+++ b/packages/core/webda.module.json
@@ -3829,5 +3829,5 @@
     "rest-domain": "Webda/RESTOperationsTransport",
     "http-server": "Webda/HttpServer"
   },
-  "sourceDigest": "e19111f71783e691cbd3cd29148374ce"
+  "sourceDigest": "16c757f0259e323af35ee4fea3962930"
 }

--- a/packages/fs/src/filestore-unit.spec.ts
+++ b/packages/fs/src/filestore-unit.spec.ts
@@ -565,8 +565,10 @@ class FileBackedMapTest {
       const repo = this.store.getRepository(MockModel);
       assert.ok(repo);
 
-      // Test the underlying FileBackedMap through the repo's storage
-      const storage = (repo as any).storage;
+      // Test the underlying FileBackedMap through the repo's storage.
+      // getRepository() returns an EventRepository wrapping the MemoryRepository,
+      // so unwrap to reach the backing storage.
+      const storage = (repo as any).repository.storage;
       assert.ok(storage);
 
       // Test set/get
@@ -617,7 +619,7 @@ class FileBackedMapTest {
       };
 
       const repo = this.store.getRepository(MockModel);
-      const storage = (repo as any).storage;
+      const storage = (repo as any).repository.storage;
 
       // Test clear on empty folder
       storage.clear();
@@ -629,6 +631,24 @@ class FileBackedMapTest {
       storage.clear();
       assert.ok(fs.existsSync(path.join(this.tmpDir, "readme.txt")));
       assert.ok(!fs.existsSync(path.join(this.tmpDir, "item1.json")));
+    });
+  }
+
+  @test
+  async repositoryEmitsTypedCreatedEvent() {
+    await runWithInstanceStorage({}, async () => {
+      const MockModel: any = class MockModel {};
+      MockModel.Metadata = {
+        Identifier: "Test/MockEvt",
+        PrimaryKey: ["uuid"],
+        Subclasses: []
+      };
+      const repo = this.store.getRepository(MockModel);
+      const seen: any[] = [];
+      repo.on("Created", (p: any) => seen.push(p));
+      await repo.create({ uuid: "evt1" } as any);
+      assert.strictEqual(seen.length, 1);
+      assert.strictEqual(seen[0].object_id, "evt1");
     });
   }
 
@@ -647,7 +667,7 @@ class FileBackedMapTest {
       };
 
       const repo = store.getRepository(MockModel);
-      const storage = (repo as any).storage;
+      const storage = (repo as any).repository.storage;
 
       // keys() on non-existent folder returns empty
       const keys = [...storage.keys()];

--- a/packages/fs/src/filestore.ts
+++ b/packages/fs/src/filestore.ts
@@ -7,6 +7,7 @@ import {
   StoreParameters,
   UpdateConditionFailError,
   MemoryRepository,
+  EventRepository,
   ModelClass,
   Repository,
   InstanceCache,
@@ -425,7 +426,11 @@ export class FileStore<K extends FileStoreParameters = FileStoreParameters> exte
   getRepository<T extends ModelClass>(model: T): Repository<T> {
     const meta = useModelMetadata(model);
     const storage = new FileBackedMap(this.parameters.folder, FileStore.EXTENSION);
-    return new MemoryRepository<T>(model, meta.PrimaryKey, undefined, storage as any) as Repository<T>;
+    const inner = new MemoryRepository<T>(model, meta.PrimaryKey, undefined, storage as any);
+    // Wrap in EventRepository so typed CRUD events fire; consumers reach them
+    // via useRepository(model).on(...). simulateFind() only calls repo.get(),
+    // which EventRepository proxies, so find() is unaffected.
+    return new EventRepository<T>(model, meta.PrimaryKey, inner) as unknown as Repository<T>;
   }
 
   /**

--- a/packages/fs/webda.module.json
+++ b/packages/fs/webda.module.json
@@ -301,5 +301,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "aeb3db279a38d6f834e626b0cee3d51e"
+  "sourceDigest": "75841b583653710bf13da471c5a02e7f"
 }

--- a/packages/graphql/src/graphql.ts
+++ b/packages/graphql/src/graphql.ts
@@ -1047,12 +1047,9 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
     }
     // Source events from the model's repository; authorization above still
     // consults the store via authorizeClientEvent.
-    return new EventIterator(
-      useRepository(model as any) as any,
-      eventsMap,
-      identifier,
-      { logout: { evt: "nok?" } }
-    ).iterate();
+    return new EventIterator(useRepository(model as any) as any, eventsMap, identifier, {
+      logout: { evt: "nok?" }
+    }).iterate();
   }
 
   /**

--- a/packages/graphql/src/graphql.ts
+++ b/packages/graphql/src/graphql.ts
@@ -10,7 +10,8 @@ import {
   useApplication,
   useCore,
   useCoreEvents,
-  useModelMetadata
+  useModelMetadata,
+  useRepository
 } from "@webda/core";
 import type { ModelGraph } from "@webda/compiler";
 import * as WebdaQL from "@webda/ql";
@@ -934,14 +935,14 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
       };
     };
     const events = {
-      "Store.Updated": updatedCallback,
+      Updated: updatedCallback,
       // Deleted is different as we need to return null
-      "Store.Deleted": async evt => {
+      Deleted: async evt => {
         if (!result.results.find(e => evt.object_id === e.getUUID())) return;
         result = await model.query(query);
         return result;
       },
-      "Store.Saved": async evt => {
+      Created: async evt => {
         // If object match the query and is not in the result and can be read by the user
         if (queryInfo.eval(evt.object) && !queryInfo.getOffset() && evt.object.canAct(context, "get")) {
           // Should check with the order by of the query to see if we need to recompute
@@ -950,10 +951,12 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
         }
         return;
       },
-      "Store.PatchUpdated": updatedCallback,
-      "Store.PartialUpdated": updatedCallback
+      Patched: updatedCallback,
+      PartialUpdated: updatedCallback
     };
-    return new EventIterator(useCore().getModelStore(model as any) as unknown as EventEmitter, events, plural, result).iterate();
+    // Listen on the model's repository typed events (Created/Updated/...) instead
+    // of the legacy Store.* events.
+    return new EventIterator(useRepository(model as any) as unknown as EventEmitter, events, plural, result).iterate();
   }
 
   /**
@@ -979,14 +982,14 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
       return model.ref(evt.object_id).get();
     };
     const events = {
-      "Store.Updated": updatedCallback,
+      Updated: updatedCallback,
       // Deleted is different as we need to return null
-      "Store.Deleted": evt => {
+      Deleted: evt => {
         if (evt.object_id !== uuid) return;
         return null;
       },
-      "Store.PatchUpdated": updatedCallback,
-      "Store.PartialUpdated": updatedCallback
+      Patched: updatedCallback,
+      PartialUpdated: updatedCallback
     };
     const modelInstance = await model.ref(uuid).get();
     // Ensure we have the permission to get the object
@@ -997,8 +1000,9 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
         }
       });
     }
+    // Listen on the model's repository typed events instead of legacy Store.* events.
     return new EventIterator(
-      useCore().getModelStore(model as any) as any,
+      useRepository(model as any) as any,
       events,
       identifier || useModelMetadata(model as any)?.Identifier,
       modelInstance
@@ -1041,8 +1045,10 @@ export class GraphQLService<T extends GraphQLParameters = GraphQLParameters> ext
         }
       });
     }
+    // Source events from the model's repository; authorization above still
+    // consults the store via authorizeClientEvent.
     return new EventIterator(
-      useCore().getModelStore(model as any) as any,
+      useRepository(model as any) as any,
       eventsMap,
       identifier,
       { logout: { evt: "nok?" } }

--- a/packages/graphql/webda.module.json
+++ b/packages/graphql/webda.module.json
@@ -147,5 +147,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "9e768955868254bd53d098cfc33e3703"
+  "sourceDigest": "61481b942922b3ce31e1fa69a60b4501"
 }

--- a/packages/graphql/webda.module.json
+++ b/packages/graphql/webda.module.json
@@ -147,5 +147,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "7d7a0d15d485a182a0ec6e27e9a95530"
+  "sourceDigest": "9e768955868254bd53d098cfc33e3703"
 }

--- a/packages/models/src/index.ts
+++ b/packages/models/src/index.ts
@@ -5,5 +5,6 @@ export * from "./repositories/hooks";
 export * from "./repositories/repository";
 export * from "./repositories/abstract";
 export * from "./repositories/memory";
+export * from "./repositories/event";
 export * from "./storable";
 export * from "./mock.js";

--- a/packages/models/src/repositories/abstract.ts
+++ b/packages/models/src/repositories/abstract.ts
@@ -277,6 +277,44 @@ export abstract class AbstractRepository<T extends ModelClass> implements Reposi
   }
 
   /**
+   * Max-listeners hint kept for Node `EventEmitter` API compatibility. Not
+   * enforced — repositories use an unbounded `Set` per event.
+   */
+  protected maxListeners = 100;
+
+  /**
+   * EventEmitter-compatibility alias for {@link off}. Consumers that treat a
+   * repository as a Node `EventEmitter` (e.g. `@webda/runtime` `EventIterator`)
+   * call `removeListener`.
+   * @param event - the event name
+   * @param listener - the listener to remove
+   */
+  removeListener<K extends keyof InstanceType<T>[typeof WEBDA_EVENTS]>(
+    event: K,
+    listener: (data: InstanceType<T>[typeof WEBDA_EVENTS][K]) => void
+  ): void {
+    this.off(event, listener);
+  }
+
+  /**
+   * EventEmitter-compatibility shim. Returns the max-listeners hint.
+   * @returns the current max-listeners hint
+   */
+  getMaxListeners(): number {
+    return this.maxListeners;
+  }
+
+  /**
+   * EventEmitter-compatibility shim. Records the max-listeners hint (no enforcement).
+   * @param n - the new hint value
+   * @returns this for chaining
+   */
+  setMaxListeners(n: number): this {
+    this.maxListeners = n;
+    return this;
+  }
+
+  /**
    * Emit an event to all registered listeners and await their completion.
    * @param event - The event name to emit
    * @param data - The event payload

--- a/packages/models/src/repositories/event.spec.ts
+++ b/packages/models/src/repositories/event.spec.ts
@@ -105,4 +105,24 @@ class EventClearTest {
     await eventRepo.create({ uuid: "test2", name: "test2", age: 2, collection: [] } as any);
     assert.strictEqual(count, 1); // unchanged - listener was removed
   }
+
+  @test
+  async eventEmitterCompatibilityShim() {
+    // Consumers like @webda/runtime EventIterator treat a repository as a Node
+    // EventEmitter: getMaxListeners/setMaxListeners + removeListener must exist.
+    const repo = new EventRepository(SubClassModel, ["uuid"], new MemoryRepository(SubClassModel, ["uuid"]));
+    assert.strictEqual(typeof repo.getMaxListeners(), "number");
+    repo.setMaxListeners(repo.getMaxListeners() + 5);
+    assert.strictEqual(repo.getMaxListeners(), 105);
+
+    let count = 0;
+    const listener = () => count++;
+    repo.on("Created" as any, listener);
+    await repo.create({ uuid: "rm1", name: "n", age: 1, collection: [] } as any);
+    assert.strictEqual(count, 1);
+    // removeListener is the EventEmitter alias for off()
+    repo.removeListener("Created" as any, listener);
+    await repo.create({ uuid: "rm2", name: "n", age: 1, collection: [] } as any);
+    assert.strictEqual(count, 1);
+  }
 }

--- a/packages/models/src/repositories/hooks.ts
+++ b/packages/models/src/repositories/hooks.ts
@@ -4,7 +4,13 @@ import { Helpers } from "../types";
 import type { Repository } from "./repository";
 import type { WebdaQLString } from "@webda/ql";
 
-/** Global registry mapping ModelClass constructors to their Repository instances. */
+/**
+ * Global registry mapping ModelClass constructors to their Repository instances.
+ *
+ * @internal — Populated by `Store.computeStores()`; not for app code. App code
+ * reaches a repository via `useRepository(Model)` or static model methods
+ * (`Model.create()`, `Model.query()`, `Model.ref()`).
+ */
 export const Repositories = new WeakMap<ModelClass, Repository<any>>();
 
 /**
@@ -25,6 +31,8 @@ export function useRepository<T extends ModelClass>(arg: T): Repository<T> {
 
 /**
  * Register a repository
+ *
+ * @internal — Called by `Store.computeStores()`; not for app code.
  * @param model - the model class to register for
  * @param repository - the repository instance
  */

--- a/packages/models/webda.module.json
+++ b/packages/models/webda.module.json
@@ -117,5 +117,5 @@
   },
   "schemas": {},
   "behaviors": {},
-  "sourceDigest": "8b5adeac8b5c225cc42c6747a8938db2"
+  "sourceDigest": "30aa180f6596f53db2c7450234608f30"
 }

--- a/packages/models/webda.module.json
+++ b/packages/models/webda.module.json
@@ -117,5 +117,5 @@
   },
   "schemas": {},
   "behaviors": {},
-  "sourceDigest": "28ce39040aa3234c997682e27b756874"
+  "sourceDigest": "bae2f5fdf68ee69bf6303d268e2ab488"
 }

--- a/packages/models/webda.module.json
+++ b/packages/models/webda.module.json
@@ -117,5 +117,5 @@
   },
   "schemas": {},
   "behaviors": {},
-  "sourceDigest": "30aa180f6596f53db2c7450234608f30"
+  "sourceDigest": "28ce39040aa3234c997682e27b756874"
 }

--- a/packages/postgres/src/postgresstore.spec.ts
+++ b/packages/postgres/src/postgresstore.spec.ts
@@ -2,8 +2,9 @@ import { suite, test } from "@webda/test";
 import * as assert from "node:assert";
 import pg from "pg";
 import { WebdaApplicationTest } from "@webda/core/lib/test";
-import { useModel } from "@webda/core";
+import { EventRepository, useModel } from "@webda/core";
 import PostgresStore from "./postgresstore.js";
+import { PostgresRepository } from "./sqlstore.js";
 
 const params = {
   postgresqlServer: {
@@ -180,5 +181,22 @@ export class PostgresStoreResolveTableTest extends WebdaApplicationTest {
       tables: { "Webda/User": "users_v2" }
     });
     assert.strictEqual(store.resolveTable(useModel("Webda/User")), "users_v2");
+  }
+
+  @test
+  async getRepositoryWrapsInEventRepository() {
+    const store = new PostgresStore("reposWrap", { models: ["Webda/Ident"], table: "idents", strict: true });
+    store.resolve();
+    const repo = store.getRepository(useModel("Webda/Ident"));
+    assert.ok(repo instanceof EventRepository);
+  }
+
+  @test
+  async getRepositoriesReturnsUnwrappedPostgresRepositories() {
+    const store = new PostgresStore("reposUnwrap", { models: ["Webda/Ident"], table: "idents", strict: true });
+    store.resolve();
+    const repos = store.getRepositories();
+    assert.ok(repos.length >= 1);
+    assert.ok(repos.every(r => r instanceof PostgresRepository));
   }
 }

--- a/packages/postgres/src/postgresstore.ts
+++ b/packages/postgres/src/postgresstore.ts
@@ -1,4 +1,4 @@
-import { InstanceCache, useApplication, useCore, useModel, useModelMetadata } from "@webda/core";
+import { EventRepository, InstanceCache, useApplication, useCore, useModel, useModelMetadata } from "@webda/core";
 import type { ModelClass, Repository } from "@webda/core";
 import { JSONSchema7 } from "json-schema";
 import pg, { ClientConfig, PoolConfig } from "pg";
@@ -171,26 +171,16 @@ export class PostgresStore<K extends PostgresParameters = PostgresParameters> ex
     if (!this.parameters.autoCreateTable) {
       return;
     }
-    // Collect the set of unique table names across all managed models
-    const tables = new Set<string>();
-    // Always include the primary configured table
-    tables.add(this.parameters.table);
-    // Also include tables for all models in the hierarchy
-    for (const modelId of Object.keys(this._modelsHierarchy ?? {})) {
-      try {
-        const model = useModel(modelId);
-        if (model) {
-          tables.add(this.resolveTable(model));
-        }
-      } catch {
-        // Model may not be resolvable — skip
+    // Delegate the per-model DDL to each PostgresRepository.setupTable().
+    // Deduplicate by table name so shared-table models don't issue redundant DDL.
+    const done = new Set<string>();
+    for (const repo of this.getRepositories()) {
+      const table = repo.getTable();
+      if (done.has(table)) {
+        continue;
       }
-    }
-    for (const table of tables) {
-      useLog("DEBUG", `CREATE TABLE IF NOT EXISTS ${table} (...)`);
-      await this.client.query(
-        `CREATE TABLE IF NOT EXISTS ${table} (uuid VARCHAR(255) NOT NULL, data jsonb, CONSTRAINT ${table}_pkey PRIMARY KEY (uuid))`
-      );
+      done.add(table);
+      await repo.setupTable();
     }
   }
 
@@ -214,7 +204,33 @@ export class PostgresStore<K extends PostgresParameters = PostgresParameters> ex
   getRepository<T extends ModelClass>(model: T): Repository<T> {
     const meta = useModelMetadata(model);
     const table = this.resolveTable(model);
-    return new PostgresRepository<T>(model, meta.PrimaryKey, this.client as any, table) as Repository<T>;
+    const inner = new PostgresRepository<T>(model, meta.PrimaryKey, this.client as any, table);
+    // Wrap in EventRepository so typed CRUD events fire; consumers reach them
+    // via useRepository(model).on(...).
+    return new EventRepository<T>(model, meta.PrimaryKey, inner) as unknown as Repository<T>;
+  }
+
+  /**
+   * Return the underlying PostgresRepository for each model this store manages,
+   * unwrapping the EventRepository produced by {@link getRepository}.
+   * @returns the per-model PostgresRepository instances
+   */
+  getRepositories(): PostgresRepository<any>[] {
+    const repos: PostgresRepository<any>[] = [];
+    for (const modelId of Object.keys(this._modelsHierarchy ?? {})) {
+      let model: ModelClass | undefined;
+      try {
+        model = useModel(modelId);
+      } catch {
+        continue;
+      }
+      if (!model) {
+        continue;
+      }
+      const repo: any = this.getRepository(model);
+      repos.push((repo.repository ?? repo) as PostgresRepository<any>);
+    }
+    return repos;
   }
 
   /**

--- a/packages/postgres/src/sqlstore.ts
+++ b/packages/postgres/src/sqlstore.ts
@@ -100,6 +100,26 @@ export class PostgresRepository<T extends ModelClass> extends MemoryRepository<T
   }
 
   /**
+   * The backing table name for this repository's model.
+   * @returns the table name
+   * @internal Not part of the @webda/models Repository interface.
+   */
+  getTable(): string {
+    return this.table;
+  }
+
+  /**
+   * Ensure the backing table for this repository's model exists.
+   * Owns the per-model DDL previously held by PostgresStore.checkTable().
+   * @internal Not part of the @webda/models Repository interface.
+   */
+  async setupTable(): Promise<void> {
+    await this.client.query(
+      `CREATE TABLE IF NOT EXISTS ${this.table} (uuid VARCHAR(255) NOT NULL, data jsonb, CONSTRAINT ${this.table}_pkey PRIMARY KEY (uuid))`
+    );
+  }
+
+  /**
    * Map an expression attribute path array to a JSONB path expression.
    * @param attribute - the attribute path
    * @returns the JSONB path expression

--- a/packages/postgres/webda.module.json
+++ b/packages/postgres/webda.module.json
@@ -2387,5 +2387,5 @@
     }
   },
   "behaviors": {},
-  "sourceDigest": "d9dfe066ac2e66d394a64fc06189b747"
+  "sourceDigest": "7814fa2b6a7d73374b53eda471d6f598"
 }


### PR DESCRIPTION
## Summary

Second of three PRs for the Repository concept refactor (follows #776). This PR makes **`Repository<T>` the single source of CRUD events**: each concrete store wraps its repository in `EventRepository`, so typed `ModelEvents` (`Created`/`Updated`/`Patched`/`Deleted`/`PartialUpdated`) fire on every operation and are reachable via `useRepository(Model).on(...)`. Per maintainer direction, downstream consumers **listen on the repository**, not on the legacy `Store.*` events — so this PR migrates graphql to repository events rather than re-emitting `Store.*` (a deviation from the original plan's Task 12).

Spec/Plan: `docs/superpowers/specs/2026-05-09-repository-design.md` (local-only, gitignored).

## What's in this PR

- **`@webda/models`** — export `EventRepository` (was implemented but unexported); add Node-`EventEmitter`-compat shims to `AbstractRepository` (`getMaxListeners`/`setMaxListeners`/`removeListener`) so a repository can be consumed by `@webda/runtime` `EventIterator`.
- **`MemoryStore`, `FileStore`, `PostgresStore`** — `getRepository()` wraps the underlying repository in `EventRepository`. `find()`/`simulateFind()` are unaffected (they only call `repository.get()`, which `EventRepository` proxies).
- **`PostgresStore`** — table DDL pushed down to `PostgresRepository.setupTable()`/`getTable()`; `getRepositories()` unwraps the `EventRepository` per managed model; `checkTable()` delegates per repository (deduped by table).
- **`@webda/core`** — re-export `EventRepository` and `useRepository`.
- **`@webda/graphql`** — query, single-instance, and generic event subscriptions now source from `useRepository(model)` and listen on typed events (`Saved` → `Created`); `authorizeClientEvent` is still consulted on the store.

## Tests

- `@webda/models` — 88 passed (new: `AbstractRepository` EventEmitter-compat shim).
- `@webda/core` — 561 passed / 1 todo (new: repository emits `Created`; `useRepository(Model).on` fires on `Model.create()`).
- `@webda/fs` — 124 passed (new: `FileStore` repository emits `Created`; storage-access tests unwrap the `EventRepository`).
- `@webda/postgres` — non-DB tests pass (new: `getRepository` wraps in `EventRepository`; `getRepositories()` unwraps to `PostgresRepository`). The 21 DB-backed failures are pre-existing `ECONNREFUSED` (no local PostgreSQL).
- Full `pnpm run build` green (except the pre-existing `docs`/Docusaurus failure). Lint clean on all touched packages.

## Verification caveats (build-only)

- **graphql tests are disabled** (`"Tests disabled — needs migration from @testdeck/mocha to @webda/test"`), so the graphql migration is **typecheck/build-verified only**. The contract it relies on (`useRepository(Model).on("Created")` fires on `Model.create()`) is covered by a new integration test in `@webda/core`.
- **postgres** DB-backed behavior (event emission, `setupTable` DDL) needs a live PostgreSQL; only construction-level tests run here.

## Out of scope (deferred)

- **`@webda/elasticsearch`** consumer migration — the package is **excluded from the pnpm workspace** (`!packages/elasticsearch`, "not yet ready"): no `node_modules`, stale `webda build`. It needs the same `useRepository(model)` migration when revived alongside its test-suite migration.
- **`aws`/`gcp`/`mongodb`** — untouched / not in active workspace (as in #776).
- `@internal` tagging, sample-app + docs migration → PR 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — Phase 3 (API positioning) added to this branch

This PR now also carries Phase 3, so it covers PRs 2 **and** 3 of the refactor.

- **`@internal` tagging** — `Store`, `StoreParameters`, `StoreInterface`, `StoreFindResult`, `StoreEvents`, `Repositories`, `registerRepository` flagged `@internal`; `useRepository` stays public. JSDoc-only, build-verified. (The plan also listed `useStore()` — it does not exist in the codebase.)
- **Agent docs** — `CLAUDE.md` "Store Pattern" → "Repository Pattern" (`Model.create/ref/query`, `useRepository(Model).on` for events); DI example no longer `@Inject`s a store; store config examples use flat `models[]`. `.github/copilot-instructions.md` config example uses `models[]`. `AGENTS.md` had no persistence section (unchanged).
- **Docs site** — new `Concepts/Stores/Repositories.md` page (canonical persistence API); `Stores.md` demoted to "storage backends — advanced" with an `@internal` banner pointing to Repositories. Markdown-only (Docusaurus build is pre-existing broken on a missing typedoc folder).
- **Sample-app migration** — no-op: `sample-apps/blog-system` (and the legacy `sample-app`) are **already Repository-first** (`User.create()`, `Post.ref().get()`), with no `@Inject(store)`/`useStore`. Verified blog-system builds clean.

### Phase 3 verification
- Full `pnpm run build` green (except pre-existing `docs`/Docusaurus). `models` 88, `core` 561+1 todo, `fs` 124 pass; `postgres` non-DB pass (21 pre-existing `ECONNREFUSED`). Lint clean on all touched packages.
